### PR TITLE
feat: add iOS Open VPN Settings

### DIFF
--- a/composeApp/src/iosMain/kotlin/org/ooni/probe/SetupDependencies.kt
+++ b/composeApp/src/iosMain/kotlin/org/ooni/probe/SetupDependencies.kt
@@ -70,18 +70,7 @@ class SetupDependencies(
         launchUrl = ::launchUrl,
         startSingleRunInner = ::startSingleRun,
         configureAutoRun = ::configureAutoRun,
-        openVpnSettings = {
-            val url = "App-prefs:General&path=ManagedConfigurationList"
-            NSURL.URLWithString(url)?.let {
-                if (UIApplication.sharedApplication.canOpenURL(it)) {
-                    UIApplication.sharedApplication.openURL(it)
-                    return@let true
-                } else {
-                    Logger.e { "Cannot open URL: $url" }
-                    return@let false
-                }
-            }?:false
-        },
+        openVpnSettings = ::openVpnSettings,
     )
 
     fun startSingleRun(spec: RunSpecification) {
@@ -245,5 +234,18 @@ class SetupDependencies(
         task.expirationHandler = { operation.cancel() }
         operation.completionBlock = { task.setTaskCompletedWithSuccess(!operation.isCancelled()) }
         operationQueue.addOperation(operation)
+    }
+
+    private fun openVpnSettings(): Boolean {
+        val url = "App-prefs:General&path=ManagedConfigurationList"
+        return NSURL.URLWithString(url)?.let {
+            if (UIApplication.sharedApplication.canOpenURL(it)) {
+                UIApplication.sharedApplication.openURL(it)
+                return@let true
+            } else {
+                Logger.e { "Cannot open URL: $url" }
+                return@let false
+            }
+        } ?: false
     }
 }

--- a/composeApp/src/iosMain/kotlin/org/ooni/probe/SetupDependencies.kt
+++ b/composeApp/src/iosMain/kotlin/org/ooni/probe/SetupDependencies.kt
@@ -70,7 +70,18 @@ class SetupDependencies(
         launchUrl = ::launchUrl,
         startSingleRunInner = ::startSingleRun,
         configureAutoRun = ::configureAutoRun,
-        openVpnSettings = { false },
+        openVpnSettings = {
+            val url = "App-prefs:General&path=ManagedConfigurationList"
+            NSURL.URLWithString(url)?.let {
+                if (UIApplication.sharedApplication.canOpenURL(it)) {
+                    UIApplication.sharedApplication.openURL(it)
+                    return@let true
+                } else {
+                    Logger.e { "Cannot open URL: $url" }
+                    return@let false
+                }
+            }?:false
+        },
     )
 
     fun startSingleRun(spec: RunSpecification) {


### PR DESCRIPTION
Note: Simulator has no VPN settings, tested on actual device device.

Not sure if this allowed.