### PR TITLE
chore: update `ios` task configuration

### DIFF
--- a/composeApp/src/dwMain/kotlin/org/ooni/probe/config/OrganizationConfig.kt
+++ b/composeApp/src/dwMain/kotlin/org/ooni/probe/config/OrganizationConfig.kt
@@ -9,7 +9,7 @@ object OrganizationConfig : OrganizationConfigInterface {
     override val ooniRunDashboardUrl = "https://run-v2.ooni.org"
     override val testDisplayMode = TestDisplayMode.WebsitesOnly
     override val autorunTaskId = "org.dw.probe.autorun-task"
-    override val updateDescriptorTaskId = "org.dw.probe.update-descriptor-task-task"
+    override val updateDescriptorTaskId = "org.dw.probe.update-descriptor-task"
     override val onboardingImages = OnboardingImages(
         image1 = Res.drawable.onboarding,
         image2 = Res.drawable.onboarding,

--- a/composeApp/src/ooniMain/kotlin/org/ooni/probe/config/OrganizationConfig.kt
+++ b/composeApp/src/ooniMain/kotlin/org/ooni/probe/config/OrganizationConfig.kt
@@ -10,7 +10,7 @@ object OrganizationConfig : OrganizationConfigInterface {
     override val ooniApiBaseUrl = "https://api.dev.ooni.io"
     override val testDisplayMode = TestDisplayMode.Regular
     override val autorunTaskId = "org.ooni.probe.autorun-task"
-    override val updateDescriptorTaskId = "org.ooni.probe.update-descriptor-task-task"
+    override val updateDescriptorTaskId = "org.ooni.probe.update-descriptor-task"
     override val onboardingImages = OnboardingImages(
         image1 = Res.drawable.onboarding1,
         image2 = Res.drawable.onboarding2,

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -38,7 +38,7 @@
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		79A29BC42C9045A80052C9D0 /* OONIProbe.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OONIProbe.entitlements; sourceTree = "<group>"; };
 		79B9D1992C6552DE004DCEE6 /* IosNetworkTypeFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosNetworkTypeFinder.swift; sourceTree = "<group>"; };
-		79FBD01A2C5A70AF004E041C /* NewsMediaScan.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NewsMediaScan.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		79FBD01A2C5A70AF004E041C /* News Media Scan.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "News Media Scan.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		79FBD01B2C5A70AF004E041C /* iosApp copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "iosApp copy-Info.plist"; path = "/Users/aanorbel/Code/ooni/new/probe-multiplatform/iosApp/iosApp copy-Info.plist"; sourceTree = "<absolute>"; };
 		8918F4B39DEEFE89FDF20821 /* Pods-iosApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.debug.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.debug.xcconfig"; sourceTree = "<group>"; };
 		93D3BF5B2C6B684800E9A9B7 /* descriptors.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = descriptors.json; sourceTree = "<group>"; };
@@ -119,7 +119,7 @@
 			isa = PBXGroup;
 			children = (
 				7555FF7B242A565900829871 /* OONI Probe.app */,
-				79FBD01A2C5A70AF004E041C /* NewsMediaScan.app */,
+				79FBD01A2C5A70AF004E041C /* News Media Scan.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -232,7 +232,7 @@
 			);
 			name = NewsMediaScan;
 			productName = iosApp;
-			productReference = 79FBD01A2C5A70AF004E041C /* NewsMediaScan.app */;
+			productReference = 79FBD01A2C5A70AF004E041C /* News Media Scan.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */


### PR DESCRIPTION
- Error object is a pointer to an error object which is set if error  occurs so a value will always exist.
- Correct task names to match entries in `*.plist`