### PR TITLE
fix: `ResultMeasurementCell` text overflow

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/result/ResultMeasurementCell.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/result/ResultMeasurementCell.kt
@@ -76,7 +76,7 @@ fun ResultMeasurementCell(
             },
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.weight(1f).padding(end = 8.dp),
         )
         if (isResultDone && measurement.isDoneAndMissingUpload) {
             Icon(

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/result/ResultMeasurementCell.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/result/ResultMeasurementCell.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import ooniprobe.composeapp.generated.resources.Res
 import ooniprobe.composeapp.generated.resources.Snackbar_ResultsNotUploaded_Text
@@ -74,6 +75,7 @@ fun ResultMeasurementCell(
                 stringResource(test.labelRes)
             },
             maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),
         )
         if (isResultDone && measurement.isDoneAndMissingUpload) {


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/82d83a6d-b2cc-4c54-9181-082dfa0f9c7a" width="200px"/>