### PR TITLE
Add database indexes

### DIFF
--- a/composeApp/src/commonMain/sqldelight/migrations/7.sqm
+++ b/composeApp/src/commonMain/sqldelight/migrations/7.sqm
@@ -1,0 +1,11 @@
+CREATE INDEX idx_result_start_time ON Result (start_time);
+CREATE INDEX idx_result_test_name ON Result (test_group_name);
+CREATE INDEX idx_result_descriptor ON Result (descriptor_runId);
+CREATE INDEX idx_result_task_origin ON Result (task_origin);
+
+CREATE INDEX idx_measure_start_time ON Measurement (start_time);
+CREATE INDEX idx_measure_is_done ON Measurement (is_done);
+CREATE INDEX idx_measure_is_uploaded ON Measurement (is_uploaded);
+CREATE INDEX idx_measure_report_id ON Measurement (report_id);
+CREATE INDEX idx_measure_is_upload_failed ON Measurement (is_upload_failed);
+CREATE INDEX idx_measure_result_id ON Measurement (result_id);


### PR DESCRIPTION
I believe these will be important for users with a lot of results and measurements, specially since we're now storing auto-runs.

I picked all fields being used for ordering and filtering of Results and Measurements, the tables that will increase the most in size, and are used most often.