### PR TITLE
Disable transition animations

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/choosewebsites/ChooseWebsitesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/choosewebsites/ChooseWebsitesScreen.kt
@@ -1,5 +1,6 @@
 package org.ooni.probe.ui.choosewebsites
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -51,7 +52,9 @@ fun ChooseWebsitesScreen(
     onEvent: (ChooseWebsitesViewModel.Event) -> Unit,
 ) {
     Column(
-        modifier = Modifier.padding(WindowInsets.navigationBars.asPaddingValues()),
+        modifier = Modifier
+            .padding(WindowInsets.navigationBars.asPaddingValues())
+            .background(MaterialTheme.colorScheme.background),
     ) {
         TopBar(
             title = { Text(stringResource(Res.string.Settings_Websites_CustomURL_Title)) },

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/dashboard/DashboardScreen.kt
@@ -73,6 +73,7 @@ fun DashboardScreen(
     PullToRefreshBox(
         isRefreshing = state.isRefreshing,
         onRefresh = { onEvent(DashboardViewModel.Event.FetchUpdatedDescriptors) },
+        modifier = Modifier.background(MaterialTheme.colorScheme.background),
     ) {
         // Colorful top background
         Column(

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/descriptor/DescriptorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/descriptor/DescriptorScreen.kt
@@ -1,5 +1,6 @@
 package org.ooni.probe.ui.descriptor
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -70,12 +71,14 @@ fun DescriptorScreen(
 
     val pullRefreshState = rememberPullToRefreshState()
     Box(
-        Modifier.pullToRefresh(
-            isRefreshing = state.isRefreshing,
-            onRefresh = { onEvent(DescriptorViewModel.Event.FetchUpdatedDescriptor) },
-            state = pullRefreshState,
-            enabled = descriptor.source is Descriptor.Source.Installed,
-        ),
+        Modifier
+            .pullToRefresh(
+                isRefreshing = state.isRefreshing,
+                onRefresh = { onEvent(DescriptorViewModel.Event.FetchUpdatedDescriptor) },
+                state = pullRefreshState,
+                enabled = descriptor.source is Descriptor.Source.Installed,
+            )
+            .background(MaterialTheme.colorScheme.background),
     ) {
         Column {
             val descriptorColor = descriptor.color ?: MaterialTheme.colorScheme.primary

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/descriptor/add/AddDescriptorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/descriptor/add/AddDescriptorScreen.kt
@@ -1,5 +1,6 @@
 package org.ooni.probe.ui.descriptor.add
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,6 +15,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -45,7 +47,7 @@ fun AddDescriptorScreen(
     onEvent: (AddDescriptorViewModel.Event) -> Unit,
 ) {
     state.descriptor?.let { descriptor ->
-        Column {
+        Column(Modifier.background(MaterialTheme.colorScheme.background)) {
             TopBar(
                 title = {
                     Text(stringResource(Res.string.AddDescriptor_Title))

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/descriptor/review/ReviewUpdatesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/descriptor/review/ReviewUpdatesScreen.kt
@@ -1,5 +1,6 @@
 package org.ooni.probe.ui.descriptor.review
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -42,7 +43,7 @@ fun ReviewUpdatesScreen(
         state.descriptors.size
     })
     val currentDescriptorIndex = state.currentDescriptorIndex + 1
-    Column {
+    Column(Modifier.background(MaterialTheme.colorScheme.background)) {
         TopBar(
             title = { Text(stringResource(Res.string.Dashboard_ReviewDescriptor_Label, currentDescriptorIndex, state.descriptors.size)) },
             actions = {

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/log/LogScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/log/LogScreen.kt
@@ -1,5 +1,6 @@
 package org.ooni.probe.ui.log
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
@@ -54,7 +55,7 @@ fun LogScreen(
     state: LogViewModel.State,
     onEvent: (LogViewModel.Event) -> Unit,
 ) {
-    Column {
+    Column(Modifier.background(MaterialTheme.colorScheme.background)) {
         TopBar(
             title = { Text(stringResource(Res.string.logs)) },
             navigationIcon = {

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/measurement/MeasurementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/measurement/MeasurementScreen.kt
@@ -1,5 +1,6 @@
 package org.ooni.probe.ui.measurement
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -66,7 +67,7 @@ fun MeasurementScreen(
         },
     )
 
-    Column {
+    Column(Modifier.background(MaterialTheme.colorScheme.background)) {
         TopBar(
             title = {
                 Text(stringResource(Res.string.measurement))

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/navigation/Navigation.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/navigation/Navigation.kt
@@ -1,5 +1,7 @@
 package org.ooni.probe.ui.navigation
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -49,6 +51,10 @@ fun Navigation(
     NavHost(
         navController = navController,
         startDestination = START_SCREEN.route,
+        enterTransition = { EnterTransition.None },
+        exitTransition = { ExitTransition.None },
+        popEnterTransition = { EnterTransition.None },
+        popExitTransition = { ExitTransition.None },
         modifier = Modifier.fillMaxSize(),
     ) {
         composable(route = Screen.Onboarding.route) {

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/result/ResultScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/result/ResultScreen.kt
@@ -83,7 +83,7 @@ fun ResultScreen(
 ) {
     var showRerunConfirmation by remember { mutableStateOf(false) }
 
-    Column {
+    Column(Modifier.background(MaterialTheme.colorScheme.background)) {
         val descriptorColor = state.result?.descriptor?.color ?: MaterialTheme.colorScheme.primary
         val onDescriptorColor = LocalCustomColors.current.onDescriptor
         TopBar(

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/results/ResultsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/results/ResultsScreen.kt
@@ -75,7 +75,7 @@ fun ResultsScreen(
 ) {
     var showDeleteConfirm by remember { mutableStateOf(false) }
 
-    Column {
+    Column(Modifier.background(MaterialTheme.colorScheme.background)) {
         TopBar(
             title = {
                 Text(stringResource(Res.string.TestResults_Overview_Title))

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/run/RunScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/run/RunScreen.kt
@@ -1,5 +1,6 @@
 package org.ooni.probe.ui.run
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -81,7 +82,7 @@ fun RunScreen(
 ) {
     var showVpnWarning by remember { mutableStateOf(false) }
 
-    Column {
+    Column(Modifier.background(MaterialTheme.colorScheme.background)) {
         TopBar(
             title = { Text(stringResource(Res.string.Dashboard_RunTests_Title)) },
             navigationIcon = {

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/settings/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package org.ooni.probe.ui.settings
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
@@ -7,6 +8,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -24,7 +26,7 @@ fun SettingsScreen(
     state: SettingsViewModel.State,
     onEvent: (SettingsViewModel.Event) -> Unit,
 ) {
-    Column {
+    Column(Modifier.background(MaterialTheme.colorScheme.background)) {
         TopBar(
             title = {
                 Text(stringResource(Res.string.Settings_Title))

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/settings/about/AboutScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/settings/about/AboutScreen.kt
@@ -1,5 +1,6 @@
 package org.ooni.probe.ui.settings.about
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -40,7 +41,7 @@ fun AboutScreen(
     softwareName: String,
     softwareVersion: String,
 ) {
-    Column {
+    Column(Modifier.background(MaterialTheme.colorScheme.background)) {
         Surface(color = MaterialTheme.colorScheme.primaryContainer) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/settings/category/SettingsCategoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/settings/category/SettingsCategoryScreen.kt
@@ -1,5 +1,6 @@
 package org.ooni.probe.ui.settings.category
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,6 +20,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -54,7 +56,7 @@ fun SettingsCategoryScreen(
 ) {
     val category = state.category ?: return
 
-    Column {
+    Column(Modifier.background(MaterialTheme.colorScheme.background)) {
         TopBar(
             title = {
                 Text(stringResource(category.title))

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/settings/proxy/ProxyScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/settings/proxy/ProxyScreen.kt
@@ -1,5 +1,6 @@
 package org.ooni.probe.ui.settings.proxy
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Arrangement
@@ -50,7 +51,7 @@ fun ProxyScreen(
     state: ProxyViewModel.State,
     onEvent: (ProxyViewModel.Event) -> Unit,
 ) {
-    Column {
+    Column(Modifier.background(MaterialTheme.colorScheme.background)) {
         TopBar(
             title = {
                 Text(stringResource(Res.string.Settings_Proxy_Enabled))


### PR DESCRIPTION
Needed to color the background of every screen to avoid overlapping content on transitions.