### PR TITLE
Test reporting improvements

### DIFF
--- a/composeApp/src/commonMain/debug/kotlin/org/ooni/probe/config/OrganizationConfigInterface.kt
+++ b/composeApp/src/commonMain/debug/kotlin/org/ooni/probe/config/OrganizationConfigInterface.kt
@@ -5,13 +5,13 @@ interface OrganizationConfigInterface {
     val baseSoftwareName: String
 
     val ooniApiBaseUrl: String
-        get() = "https://api.ooni.org"
+        get() = "https://api.dev.ooni.io"
 
     val ooniRunDomain: String
-        get() = "run.ooni.org"
+        get() = "run.test.ooni.org"
 
     val ooniRunDashboardUrl: String
-        get() = "https://run.ooni.org"
+        get() = "https://run.test.ooni.org"
 
     val explorerUrl: String
         get() = "https://explorer.test.ooni.org"

--- a/composeApp/src/commonMain/kotlin/org/ooni/engine/TaskEventMapper.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/engine/TaskEventMapper.kt
@@ -9,7 +9,10 @@ class TaskEventMapper(
     private val networkTypeFinder: NetworkTypeFinder,
     private val json: Json,
 ) {
-    operator fun invoke(result: TaskEventResult): TaskEvent? {
+    operator fun invoke(
+        result: TaskEventResult,
+        isCancelled: Boolean = false,
+    ): TaskEvent? {
         val key = result.key
         val value = result.value
 
@@ -33,6 +36,7 @@ class TaskEventMapper(
                     TaskEvent.ResolverLookupFailure(
                         message = value.failure,
                         value = value,
+                        isCancelled = isCancelled,
                     )
                 } ?: run {
                     Logger.d("Task Event $key missing 'value'")
@@ -44,6 +48,7 @@ class TaskEventMapper(
                     TaskEvent.StartupFailure(
                         message = value.failure,
                         value = value,
+                        isCancelled = isCancelled,
                     )
                 } ?: run {
                     Logger.d("Task Event $key missing 'value'")

--- a/composeApp/src/commonMain/kotlin/org/ooni/engine/models/TaskEvent.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/engine/models/TaskEvent.kt
@@ -59,6 +59,7 @@ sealed interface TaskEvent {
     data class ResolverLookupFailure(
         val message: String?,
         val value: TaskEventResult.Value,
+        val isCancelled: Boolean,
     ) : TaskEvent
 
     data object Started : TaskEvent
@@ -66,9 +67,17 @@ sealed interface TaskEvent {
     data class StartupFailure(
         val message: String?,
         val value: TaskEventResult.Value,
+        val isCancelled: Boolean,
     ) : TaskEvent
 
     data class TaskTerminated(
         val index: Int,
     ) : TaskEvent
+
+    fun isCancelled() =
+        when (this) {
+            is StartupFailure -> isCancelled
+            is ResolverLookupFailure -> isCancelled
+            else -> null
+        }
 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunNetTest.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunNetTest.kt
@@ -221,7 +221,7 @@ class RunNetTest(
 
             is TaskEvent.StartupFailure,
             is TaskEvent.ResolverLookupFailure,
-            -> {
+                -> {
                 val message = when (event) {
                     is TaskEvent.StartupFailure -> event.message
                     is TaskEvent.ResolverLookupFailure -> event.message
@@ -232,22 +232,24 @@ class RunNetTest(
                     updateResult {
                         it.copy(
                             failureMessage =
-                                if (it.failureMessage != null) {
-                                    "${it.failureMessage}\n$message"
-                                } else {
-                                    message
-                                },
+                            if (it.failureMessage != null) {
+                                "${it.failureMessage}\n$message"
+                            } else {
+                                message
+                            },
                         )
                     }
                 }
 
-                val value = when (event) {
-                    is TaskEvent.StartupFailure -> event.value
-                    is TaskEvent.ResolverLookupFailure -> event.value
-                    else -> null
-                } ?: return
+                when (event) {
+                    is TaskEvent.StartupFailure ->
+                        Logger.w(message ?: "StartupFailure", Failure(event.value))
 
-                Logger.w(message ?: "Failure", Failure(value))
+                    is TaskEvent.ResolverLookupFailure ->
+                        Logger.i(message ?: "ResolverLookupFailure", Failure(event.value))
+
+                    else -> Unit
+                }
             }
 
             is TaskEvent.BugJsonDump -> {

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/onboarding/OnboardingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/onboarding/OnboardingScreen.kt
@@ -372,7 +372,7 @@ fun ColumnScope.RequestPermissionStep(onEvent: (OnboardingViewModel.Event) -> Un
                         Logger.i("Permission request cancelled")
                         // Nothing to do here
                     } catch (e: Exception) {
-                        Logger.e("Error requesting permission")
+                        Logger.e("Error requesting permission", e)
                     }
                 }
             },


### PR DESCRIPTION
- Don't report ResolverLookupFailures
- Skip reporting StartupFailures if the user stopped/cancelled the test
- Report ResolverLookupFailure, StartupFailures and BugJsonDump always using an exception, to see if they are grouped together on Sentry
- Revert debug urls back to `dev`