### PR TITLE
Suppress LookupHost failed error reports

### DIFF
--- a/composeApp/src/commonFullMain/kotlin/org/ooni/probe/shared/monitoring/CrashMonitoring.kt
+++ b/composeApp/src/commonFullMain/kotlin/org/ooni/probe/shared/monitoring/CrashMonitoring.kt
@@ -43,7 +43,10 @@ class CrashMonitoring(
         ) {
             if (!Sentry.isEnabled()) return
 
-            if (severity == Severity.Warn || severity == Severity.Error) {
+            if (
+                (severity == Severity.Warn || severity == Severity.Error) &&
+                MESSAGES_TO_SKIP_REPORT.none { message.contains(it) }
+            ) {
                 if (throwable != null) {
                     addBreadcrumb(severity, message, tag)
                     Sentry.captureException(throwable)
@@ -82,5 +85,12 @@ class CrashMonitoring(
                 ),
             )
         }
+    }
+
+    companion object {
+        private val MESSAGES_TO_SKIP_REPORT = listOf(
+            "Picking from default OpenVPN endpoints",
+            "sessionresolver: LookupHost failed",
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunNetTest.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunNetTest.kt
@@ -112,11 +112,9 @@ class RunNetTest(
 
             is TaskEvent.Log -> {
                 Logger.log(
-                    severity = when {
-                        event.level == "WARNING" && !LOGS_TO_LOWER_LEVEL.contains(event.message) ->
-                            Severity.Warn
-
-                        event.level == "DEBUG" -> Severity.Debug
+                    severity = when (event.level) {
+                        "WARNING" -> Severity.Warn
+                        "DEBUG" -> Severity.Debug
                         else -> Severity.Info
                     },
                     message = event.message,
@@ -317,10 +315,4 @@ class RunNetTest(
         Failure(message, value)
 
     inner class BugJsonDump(value: TaskEventResult.Value?) : Failure(null, value)
-
-    companion object {
-        private val LOGS_TO_LOWER_LEVEL = listOf(
-            "Picking from default OpenVPN endpoints",
-        )
-    }
 }

--- a/composeApp/src/iosMain/kotlin/org/ooni/probe/SetupDependencies.kt
+++ b/composeApp/src/iosMain/kotlin/org/ooni/probe/SetupDependencies.kt
@@ -194,7 +194,7 @@ class SetupDependencies(
         }
     }
 
-    private fun presentViewController(uiViewController: UIViewController): Boolean  {
+    private fun presentViewController(uiViewController: UIViewController): Boolean {
         return findCurrentViewController()?.let { viewController ->
 
             if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {


### PR DESCRIPTION
We were getting too many individual LookupHost failed reports on Sentry.