### PR TITLE
Android in-app updates

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -203,8 +203,17 @@ android {
             "src/commonMain/res",
         ),
     )
+    productFlavors {
+        create("full") {
+            dimension = "license"
+        }
+        create("fdroid") {
+            dimension = "license"
+        }
+    }
     dependencies {
         debugImplementation(compose.uiTooling)
+        "fullImplementation"(libs.bundles.full.android)
         androidTestUtil(libs.android.orchestrator)
     }
     testOptions {
@@ -216,14 +225,6 @@ android {
         lintConfig = file("lint.xml")
     }
     flavorDimensions += "license"
-    productFlavors {
-        create("full") {
-            dimension = "license"
-        }
-        create("fdroid") {
-            dimension = "license"
-        }
-    }
 }
 
 sqldelight {

--- a/composeApp/src/androidFdroid/kotlin/org/ooni/probe/config/AndroidUpdateMonitoring.kt
+++ b/composeApp/src/androidFdroid/kotlin/org/ooni/probe/config/AndroidUpdateMonitoring.kt
@@ -1,0 +1,7 @@
+package org.ooni.probe.config
+
+import android.app.Activity
+
+class AndroidUpdateMonitoring : UpdateMonitoring {
+    override fun onResume(activity: Activity) {}
+}

--- a/composeApp/src/androidFull/kotlin/org/ooni/probe/config/AndroidUpdateMonitoring.kt
+++ b/composeApp/src/androidFull/kotlin/org/ooni/probe/config/AndroidUpdateMonitoring.kt
@@ -1,0 +1,89 @@
+package org.ooni.probe.config
+
+import android.app.Activity
+import android.app.AlertDialog
+import com.google.android.play.core.appupdate.AppUpdateManager
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.install.InstallState
+import com.google.android.play.core.install.InstallStateUpdatedListener
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.InstallStatus
+import com.google.android.play.core.install.model.UpdateAvailability
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import ooniprobe.composeapp.generated.resources.Dashboard_Update_Ready
+import ooniprobe.composeapp.generated.resources.Dashboard_Update_Restart
+import ooniprobe.composeapp.generated.resources.Res
+import org.jetbrains.compose.resources.getString
+
+// We want to do a Flexible update: the download happens in the background
+// while the user continues using the app, and we show a warning when it's ready
+// to restart
+class AndroidUpdateMonitoring : UpdateMonitoring {
+    private var checkedIfUpdateIsAvailable = false
+    private var userStartedUpdate = false
+
+    override fun onResume(activity: Activity) {
+        val appUpdateManager = AppUpdateManagerFactory.create(activity)
+        val installListener = object : InstallStateUpdatedListener {
+            override fun onStateUpdate(state: InstallState) {
+                if (state.installStatus() == InstallStatus.DOWNLOADED) {
+                    appUpdateManager.showInstallDownloadedUpdateMessage(activity)
+                    appUpdateManager.unregisterListener(this)
+                }
+            }
+        }
+
+        if (!checkedIfUpdateIsAvailable) {
+            // We only check once at app start
+            val appUpdateInfoTask = appUpdateManager.appUpdateInfo
+            appUpdateInfoTask.addOnSuccessListener { info ->
+                if (
+                    info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
+                    info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)
+                ) {
+                    // Register listener to know when the app finishes downloading
+                    appUpdateManager.registerListener(installListener)
+                    appUpdateManager.startUpdateFlowForResult(
+                        info,
+                        activity,
+                        AppUpdateOptions
+                            .newBuilder(AppUpdateType.FLEXIBLE)
+                            .build(),
+                        ACTIVITY_CODE,
+                    )
+                    userStartedUpdate = true
+                }
+            }
+            checkedIfUpdateIsAvailable = true
+        } else if (userStartedUpdate) {
+            // If the update download finished when the app was in the background,
+            // we still need the user to complete it
+            appUpdateManager
+                .appUpdateInfo
+                .addOnSuccessListener { appUpdateInfo ->
+                    if (appUpdateInfo.installStatus() == InstallStatus.DOWNLOADED) {
+                        appUpdateManager.showInstallDownloadedUpdateMessage(activity)
+                    }
+                }
+        }
+    }
+
+    // Update is downloaded but not installed, we need to ask the user to complete the update
+    private fun AppUpdateManager.showInstallDownloadedUpdateMessage(activity: Activity) {
+        CoroutineScope(Dispatchers.Main).launch {
+            AlertDialog.Builder(activity)
+                .setMessage(getString(Res.string.Dashboard_Update_Ready))
+                .setPositiveButton(
+                    getString(Res.string.Dashboard_Update_Restart),
+                ) { _, _ -> completeUpdate() }
+                .show()
+        }
+    }
+
+    companion object {
+        private const val ACTIVITY_CODE = 1
+    }
+}

--- a/composeApp/src/androidMain/kotlin/org/ooni/probe/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/ooni/probe/MainActivity.kt
@@ -15,12 +15,15 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.MutableSharedFlow
+import org.ooni.probe.config.AndroidUpdateMonitoring
 import org.ooni.probe.config.OrganizationConfig
+import org.ooni.probe.config.UpdateMonitoring
 import org.ooni.probe.data.models.DeepLink
 
 class MainActivity : ComponentActivity() {
     private val deepLinkFlow = MutableSharedFlow<DeepLink?>(extraBufferCapacity = 1)
     private val app get() = applicationContext as AndroidApplication
+    private val updateMonitoring: UpdateMonitoring = AndroidUpdateMonitoring()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
@@ -42,6 +45,11 @@ class MainActivity : ComponentActivity() {
                 intent?.let { manageIntent(it) }
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        updateMonitoring.onResume(this)
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/composeApp/src/androidMain/kotlin/org/ooni/probe/config/UpdateMonitoring.kt
+++ b/composeApp/src/androidMain/kotlin/org/ooni/probe/config/UpdateMonitoring.kt
@@ -1,0 +1,7 @@
+package org.ooni.probe.config
+
+import android.app.Activity
+
+interface UpdateMonitoring {
+    fun onResume(activity: Activity)
+}

--- a/composeApp/src/commonMain/composeResources/values/strings-common.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings-common.xml
@@ -307,9 +307,10 @@
     <string name="Modal_EnableNotifications_Title">Get updates on internet censorship</string>
 
     <string name="Dashboard_Runv2_Overview_LastUpdated">Last updated %1$s</string>
-
     <string name="Dashboard_RunTests_RunButton_Label_One">Run %1$d test</string>
     <string name="Dashboard_RunTests_RunButton_Label_Other">Run %1$d tests</string>
+    <string name="Dashboard_Update_Ready">The app update has just been downloaded</string>
+    <string name="Dashboard_Update_Restart">Restart</string>
 
     <string name="AddDescriptor_Toasts_Unsupported_Url">Unsupported URL</string>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,6 +71,9 @@ markdown = { module = "com.mikepenz:multiplatform-markdown-renderer-m3", version
 # WebView
 web-view = { module = "io.github.kevinnzou:compose-webview-multiplatform", version = "1.9.40-alpha04" }
 
+# In-App Updates
+android-app-update = { module = "com.google.android.play:app-update-ktx", version = "2.1.0" }
+
 # Android Testing
 android-test-core = { module = "androidx.test:core", version = "1.6.1" }
 
@@ -112,6 +115,9 @@ android = [
 ]
 full = [
     "sentry",
+]
+full-android = [
+    "android-app-update",
 ]
 android-test = [
     "android-test-core"


### PR DESCRIPTION
Closes #361 

Followed the instructions on https://developer.android.com/guide/playcore/in-app-updates/kotlin-java#kotlin
It should be working, but we can only make sure once we start using the internal track on google play.

This is how the alert dialog looks once the update started by the user has finished downloading in the background:
<img width="329" alt="Screenshot 2025-01-07 at 12 15 33" src="https://github.com/user-attachments/assets/5f6fb38c-070b-4053-8ad0-3130384124e5" />
