### PR TITLE
Background work documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Multiplatform (Android and iOS currently) version of the Probe app.
 
-![Validate](https://github.com/ooni/probe-multiplatform/actions/workflows/validate.yml/badge.svg)
-![Android Instrumented Tests](https://github.com/ooni/probe-multiplatform/actions/workflows/instrumented-tests.yml/badge.svg)
+[![Validate](https://github.com/ooni/probe-multiplatform/actions/workflows/validate.yml/badge.svg)](https://github.com/ooni/probe-multiplatform/actions/workflows/validate.yml)
+[![Android Instrumented Tests](https://github.com/ooni/probe-multiplatform/actions/workflows/instrumented-tests.yml/badge.svg)](https://github.com/ooni/probe-multiplatform/actions/workflows/instrumented-tests.yml)
 
 ## Project structure
 

--- a/composeApp/src/androidMain/kotlin/org/ooni/probe/background/AppWorkerManager.kt
+++ b/composeApp/src/androidMain/kotlin/org/ooni/probe/background/AppWorkerManager.kt
@@ -66,7 +66,7 @@ class AppWorkerManager(
                 .setConstraints(
                     Constraints.Builder()
                         .setRequiredNetworkType(NetworkType.CONNECTED)
-                        .build()
+                        .build(),
                 )
                 .build()
             workManager.enqueueUniquePeriodicWork(

--- a/composeApp/src/androidMain/kotlin/org/ooni/probe/background/AppWorkerManager.kt
+++ b/composeApp/src/androidMain/kotlin/org/ooni/probe/background/AppWorkerManager.kt
@@ -44,7 +44,7 @@ class AppWorkerManager(
                 .setConstraints(
                     Constraints.Builder()
                         .setRequiredNetworkType(
-                            if (params.wifiOnly) NetworkType.UNMETERED else NetworkType.NOT_REQUIRED,
+                            if (params.wifiOnly) NetworkType.UNMETERED else NetworkType.CONNECTED,
                         )
                         .setRequiresCharging(params.onlyWhileCharging)
                         .build(),
@@ -63,6 +63,11 @@ class AppWorkerManager(
         return withContext(backgroundDispatcher) {
             val request = PeriodicWorkRequestBuilder<DescriptorUpdateWorker>(1, TimeUnit.DAYS)
                 .setInitialDelay(1, TimeUnit.DAYS) // avoid immediate start
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
                 .build()
             workManager.enqueueUniquePeriodicWork(
                 DescriptorUpdateWorker.AutoUpdateWorkerName,
@@ -83,10 +88,7 @@ class AppWorkerManager(
                         .setInputData(
                             descriptors?.let {
                                 DescriptorUpdateWorker.buildWorkData(
-                                    it.map {
-                                            descriptor ->
-                                        descriptor.id
-                                    },
+                                    it.map { descriptor -> descriptor.id },
                                 )
                             } ?: Data.EMPTY,
                         )

--- a/docs/BackgroundWork.md
+++ b/docs/BackgroundWork.md
@@ -1,0 +1,35 @@
+# Background Work
+
+The Probe Multiplatform App has two different background-tasks:
+
+**1. Running Tests**
+
+Manual and automatic running of descriptor tests.
+
+When:
+* If auto-run is enabled, it runs roughly every hour, if the constraint the user picked in the
+  settings apply (only on WiFi or when device is charging). It runs with a specification based on
+  the descriptors and tests enabled for auto-run.
+* It can be triggered manually when the user runs tests inside the app, with the specification they
+  picked.
+
+**2. Descriptor Update**
+
+Fetch all the installed descriptors to check if any has a more up-to-date version. If they do, it
+either updates automatically the descriptor, or warns the user that there's an update to approve.
+
+When:
+* App start
+* If the user pulls-down to refresh on the Dashboard screen, or a specific Descriptor screen
+* Once per day, if the device if connected to any Network.
+
+## Implementation
+
+### Android
+
+Work is scheduled and ran using [WorkManager](https://developer.android.com/topic/libraries/architecture/workmanager) ([source](https://github.com/ooni/probe-multiplatform/blob/main/composeApp/src/androidMain/kotlin/org/ooni/probe/background/AppWorkerManager.kt)).
+
+### iOS
+
+Work is scheduled using [BGTaskScheduler](https://developer.apple.com/documentation/UIKit/using-background-tasks-to-update-your-app) ([source](https://github.com/ooni/probe-multiplatform/blob/main/composeApp/src/iosMain/kotlin/org/ooni/probe/background/OperationsManager.kt)).
+It runs in a background thread using [DispatchQueue](https://developer.apple.com/documentation/dispatch/dispatchqueue) ([source](https://github.com/ooni/probe-multiplatform/blob/main/iosApp/iosApp/background/IosBackgroundRunner.swift)).


### PR DESCRIPTION
I also noticed that our Android workers didn't have the `NetworkType.CONNECTED` and I believe they should have. There's nothing to test or update without any kind of Internet connection.