### PR TITLE
Fix review descriptor bugs

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/data/models/Descriptor.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/data/models/Descriptor.kt
@@ -34,12 +34,19 @@ data class Descriptor(
 
     val isExpired get() = expirationDate != null && expirationDate < LocalDateTime.now()
 
-    val updatable get() = updateStatus is UpdateStatus.UpdateRejected
+    val updatable get() = updatedDescriptor != null
+
+    val updatedDescriptor
+        get() = when (updateStatus) {
+            is UpdateStatus.Updatable -> updateStatus.updatedDescriptor
+            is UpdateStatus.UpdateRejected -> updateStatus.updatedDescriptor
+            else -> null
+        }
 
     val key: String
         get() = when (source) {
             is Source.Default -> name
-            is Source.Installed -> source.value.id.value.toString()
+            is Source.Installed -> source.value.id.value
         }
 
     val allTests get() = netTests + longRunningTests

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
@@ -291,7 +291,7 @@ class Dependencies(
             getDefaultTestDescriptors = getDefaultTestDescriptors::invoke,
             listAllInstalledTestDescriptors = testDescriptorRepository::listAll,
             listLatestInstalledTestDescriptors = testDescriptorRepository::listLatest,
-            descriptorUpdates = getDescriptorUpdate::observeAvailableUpdatesState,
+            descriptorUpdates = getDescriptorUpdate::observeStatus,
             getPreferenceValues = preferenceRepository::allSettings,
         )
     }
@@ -426,7 +426,7 @@ class Dependencies(
         observeTestRunErrors = runBackgroundStateManager.observeErrors(),
         shouldShowVpnWarning = shouldShowVpnWarning::invoke,
         fetchDescriptorUpdate = fetchDescriptorUpdate,
-        observeAvailableUpdatesState = getDescriptorUpdate::observeAvailableUpdatesState,
+        observeAvailableUpdatesState = getDescriptorUpdate::observeStatus,
         reviewUpdates = getDescriptorUpdate::reviewUpdates,
         cancelUpdates = getDescriptorUpdate::cancelUpdates,
     )
@@ -449,7 +449,7 @@ class Dependencies(
         fetchDescriptorUpdate = fetchDescriptorUpdate,
         setAutoUpdate = testDescriptorRepository::setAutoUpdate,
         reviewUpdates = getDescriptorUpdate::reviewUpdates,
-        descriptorUpdates = getDescriptorUpdate::observeAvailableUpdatesState,
+        descriptorUpdates = getDescriptorUpdate::observeStatus,
     )
 
     fun logViewModel(onBack: () -> Unit) =
@@ -537,8 +537,9 @@ class Dependencies(
         return ReviewUpdatesViewModel(
             onBack = onBack,
             saveTestDescriptors = saveTestDescriptors::invoke,
+            observeAvailableUpdatesState = getDescriptorUpdate::observeStatus,
             cancelUpdates = getDescriptorUpdate::cancelUpdates,
-            observeAvailableUpdatesState = getDescriptorUpdate::observeAvailableUpdatesState,
+            markAsUpdated = getDescriptorUpdate::markAsUpdated,
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/dashboard/DashboardScreen.kt
@@ -112,6 +112,9 @@ fun DashboardScreen(
                             onClick = {
                                 onEvent(DashboardViewModel.Event.DescriptorClicked(descriptor))
                             },
+                            onUpdateClick = {
+                                onEvent(DashboardViewModel.Event.UpdateDescriptorClicked(descriptor))
+                            },
                         )
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/dashboard/DashboardViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/dashboard/DashboardViewModel.kt
@@ -134,6 +134,19 @@ class DashboardViewModel(
             .launchIn(viewModelScope)
 
         events
+            .filterIsInstance<Event.UpdateDescriptorClicked>()
+            .onEach {
+                reviewUpdates(
+                    listOf(
+                        (it.descriptor.source as? Descriptor.Source.Installed)?.value
+                            ?: return@onEach,
+                    ),
+                )
+                goToReviewDescriptorUpdates()
+            }
+            .launchIn(viewModelScope)
+
+        events
             .filterIsInstance<Event.CancelUpdatesClicked>()
             .onEach {
                 cancelUpdates(state.value.availableUpdates)
@@ -180,6 +193,8 @@ class DashboardViewModel(
         data class ErrorDisplayed(val error: TestRunError) : Event
 
         data class DescriptorClicked(val descriptor: Descriptor) : Event
+
+        data class UpdateDescriptorClicked(val descriptor: Descriptor) : Event
 
         data object FetchUpdatedDescriptors : Event
 

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/dashboard/TestDescriptorItem.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/dashboard/TestDescriptorItem.kt
@@ -26,7 +26,7 @@ import org.ooni.probe.ui.shared.UpdatesChip
 fun TestDescriptorItem(
     descriptor: Descriptor,
     onClick: () -> Unit,
-    updateDescriptor: () -> Unit = {},
+    onUpdateClick: () -> Unit,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -55,7 +55,7 @@ fun TestDescriptorItem(
             }
         }
         if (descriptor.updatable) {
-            UpdatesChip(onClick = updateDescriptor)
+            UpdatesChip(onClick = onUpdateClick)
         }
         if (descriptor.isExpired) {
             ExpiredChip()

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/descriptor/DescriptorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/descriptor/DescriptorScreen.kt
@@ -54,6 +54,7 @@ import org.ooni.probe.config.OrganizationConfig
 import org.ooni.probe.config.TestDisplayMode
 import org.ooni.probe.data.models.Descriptor
 import org.ooni.probe.data.models.NetTest
+import org.ooni.probe.data.models.UpdateStatus
 import org.ooni.probe.ui.shared.ExpiredChip
 import org.ooni.probe.ui.shared.MarkdownViewer
 import org.ooni.probe.ui.shared.SelectableItem
@@ -261,15 +262,16 @@ private fun DescriptorDetails(
                 }
             }
 
-            if (descriptor.updatable) {
-                UpdatesChip(onClick = { }, modifier = Modifier.padding(top = 8.dp))
-            }
-
             if (descriptor.isExpired) {
                 ExpiredChip()
             }
 
-            state.updatedDescriptor?.let {
+            if (descriptor.updateStatus is UpdateStatus.UpdateRejected) {
+                UpdatesChip(
+                    onClick = { onEvent(DescriptorViewModel.Event.UpdateDescriptor) },
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+            } else if (descriptor.updateStatus is UpdateStatus.Updatable) {
                 OutlinedButton(
                     onClick = { onEvent(DescriptorViewModel.Event.UpdateDescriptor) },
                     border = ButtonDefaults.outlinedButtonBorder(enabled = true).copy(

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/descriptor/review/ReviewUpdatesViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/descriptor/review/ReviewUpdatesViewModel.kt
@@ -17,8 +17,9 @@ import org.ooni.probe.domain.SaveTestDescriptors
 class ReviewUpdatesViewModel(
     private val onBack: () -> Unit,
     saveTestDescriptors: suspend (List<InstalledTestDescriptorModel>, SaveTestDescriptors.Mode) -> Unit,
-    cancelUpdates: (List<InstalledTestDescriptorModel>) -> Unit,
     observeAvailableUpdatesState: () -> Flow<DescriptorUpdatesStatus>,
+    cancelUpdates: (List<InstalledTestDescriptorModel>) -> Unit,
+    markAsUpdated: (List<InstalledTestDescriptorModel>) -> Unit,
 ) : ViewModel() {
     private val events = MutableSharedFlow<Event>(extraBufferCapacity = 1)
 
@@ -52,6 +53,7 @@ class ReviewUpdatesViewModel(
                             listOf(descriptor),
                             SaveTestDescriptors.Mode.CreateOrUpdate,
                         )
+                        markAsUpdated(listOf(descriptor))
                         navigateToNextItemOrClose(it.index)
                     } else {
                         onBack()

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/shared/UpdatesChip.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/shared/UpdatesChip.kt
@@ -1,6 +1,6 @@
 package org.ooni.probe.ui.shared
 
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.SuggestionChipDefaults
 import androidx.compose.material3.Text
@@ -17,9 +17,12 @@ fun UpdatesChip(
 ) {
     SuggestionChip(
         onClick = onClick,
-        enabled = false,
         colors = SuggestionChipDefaults.suggestionChipColors(
-            labelColor = MaterialTheme.colorScheme.error,
+            labelColor = LocalContentColor.current,
+        ),
+        border = SuggestionChipDefaults.suggestionChipBorder(
+            enabled = true,
+            borderColor = LocalContentColor.current,
         ),
         label = { Text(stringResource(Res.string.Dashboard_RunV2_UpdateTag)) },
         modifier = modifier,

--- a/composeApp/src/commonTest/kotlin/org/ooni/probe/domain/FetchDescriptorUpdateTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/probe/domain/FetchDescriptorUpdateTest.kt
@@ -29,7 +29,7 @@ class FetchDescriptorUpdateTest {
 
             subject()
 
-            val state = subject.observeAvailableUpdatesState().value
+            val state = subject.observeStatus().value
 
             assertEquals(0, state.autoUpdated.size)
             assertEquals(UpdateStatusType.None, state.refreshType)
@@ -56,7 +56,7 @@ class FetchDescriptorUpdateTest {
 
             subject()
 
-            val state = subject.observeAvailableUpdatesState().value
+            val state = subject.observeStatus().value
 
             assertEquals(1, state.autoUpdated.size)
             assertEquals(UpdateStatusType.None, state.refreshType)
@@ -83,7 +83,7 @@ class FetchDescriptorUpdateTest {
 
             subject()
 
-            val state = subject.observeAvailableUpdatesState().value
+            val state = subject.observeStatus().value
 
             assertEquals(1, state.availableUpdates.size)
             assertEquals(0, state.reviewUpdates.size)
@@ -92,7 +92,7 @@ class FetchDescriptorUpdateTest {
 
             subject.reviewUpdates(listOf(newDescriptor))
 
-            val reviewState = subject.observeAvailableUpdatesState().value
+            val reviewState = subject.observeStatus().value
 
             assertEquals(1, reviewState.reviewUpdates.size)
             assertEquals(UpdateStatusType.None, reviewState.refreshType)


### PR DESCRIPTION
Closes #378
Closes #379

Main changes are the `markAsUpdated` method and using just the `descriptor.updateStatus` inside the DescriptorScreen/ViewModel.