### PR TITLE
Improve StartupFailure/ResolverLookupFailure message

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunNetTest.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunNetTest.kt
@@ -304,15 +304,8 @@ class RunNetTest(
         )
     }
 
-    open inner class Failure(message: String?, value: TaskEventResult.Value?) : Exception(
-        if (message != null && value != null) {
-            message + "\n" + json.encodeToString(value)
-        } else if (value != null) {
-            json.encodeToString(value)
-        } else {
-            message ?: ""
-        },
-    )
+    open inner class Failure(message: String?, value: TaskEventResult.Value?) :
+        Exception(message ?: value?.let(json::encodeToString))
 
     inner class StartupFailure(message: String?, value: TaskEventResult.Value?) :
         Failure(message, value)


### PR DESCRIPTION
Closes #395

We are already splitting the MKException into StartupFailure/ResolverLookupFailure, and we're taking the failure message from the event value. Here's how the errors currently look on Sentry:
https://ooni.sentry.io/issues/6216424916/?project=4508325650235392
https://ooni.sentry.io/issues/6225238701/?project=4508325650235392

I just improve the messaging, because we don't need the json if we have the failure message.
