### PR TITLE
Foreground Service Mitigations

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -85,6 +86,12 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths" />
         </provider>
+
+        <!-- https://developer.android.com/develop/background-work/background-tasks/persistent/how-to/long-running#declare-foreground-service-types-manifest -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
 
     </application>
 

--- a/composeApp/src/androidMain/kotlin/org/ooni/probe/background/EarlyStopWorkerException.kt
+++ b/composeApp/src/androidMain/kotlin/org/ooni/probe/background/EarlyStopWorkerException.kt
@@ -1,0 +1,65 @@
+package org.ooni.probe.background
+
+import androidx.work.WorkInfo
+
+open class EarlyStopWorkerException(reason: Int?) :
+    Exception("Early stop due to ${reasonToString(reason)}") {
+    companion object {
+        private fun reasonToString(reason: Int?) =
+            when (reason) {
+                WorkInfo.STOP_REASON_FOREGROUND_SERVICE_TIMEOUT ->
+                    "STOP_REASON_FOREGROUND_SERVICE_TIMEOUT"
+
+                WorkInfo.STOP_REASON_UNKNOWN ->
+                    "STOP_REASON_UNKNOWN"
+
+                WorkInfo.STOP_REASON_CANCELLED_BY_APP ->
+                    "STOP_REASON_CANCELLED_BY_APP"
+
+                WorkInfo.STOP_REASON_PREEMPT ->
+                    "STOP_REASON_PREEMPT"
+
+                WorkInfo.STOP_REASON_TIMEOUT ->
+                    "STOP_REASON_TIMEOUT"
+
+                WorkInfo.STOP_REASON_DEVICE_STATE ->
+                    "STOP_REASON_DEVICE_STATE"
+
+                WorkInfo.STOP_REASON_CONSTRAINT_BATTERY_NOT_LOW ->
+                    "STOP_REASON_CONSTRAINT_BATTERY_NOT_LOW"
+
+                WorkInfo.STOP_REASON_CONSTRAINT_CHARGING ->
+                    "STOP_REASON_CONSTRAINT_CHARGING"
+
+                WorkInfo.STOP_REASON_CONSTRAINT_CONNECTIVITY ->
+                    "STOP_REASON_CONSTRAINT_CONNECTIVITY"
+
+                WorkInfo.STOP_REASON_CONSTRAINT_DEVICE_IDLE ->
+                    "STOP_REASON_CONSTRAINT_DEVICE_IDLE"
+
+                WorkInfo.STOP_REASON_CONSTRAINT_STORAGE_NOT_LOW ->
+                    "STOP_REASON_CONSTRAINT_STORAGE_NOT_LOW"
+
+                WorkInfo.STOP_REASON_QUOTA ->
+                    "STOP_REASON_QUOTA"
+
+                WorkInfo.STOP_REASON_BACKGROUND_RESTRICTION ->
+                    "STOP_REASON_BACKGROUND_RESTRICTION"
+
+                WorkInfo.STOP_REASON_APP_STANDBY ->
+                    "STOP_REASON_APP_STANDBY"
+
+                WorkInfo.STOP_REASON_USER ->
+                    "STOP_REASON_USER"
+
+                WorkInfo.STOP_REASON_SYSTEM_PROCESSING ->
+                    "STOP_REASON_SYSTEM_PROCESSING"
+
+                WorkInfo.STOP_REASON_ESTIMATED_APP_LAUNCH_TIME_CHANGED ->
+                    "STOP_REASON_ESTIMATED_APP_LAUNCH_TIME_CHANGED"
+
+                else ->
+                    reason.toString()
+            }
+    }
+}


### PR DESCRIPTION
Closes #405 

setForeground on workers with foreground service type.
Handle restrictions and early stops. Timeouts and other early stops are catched as CancellationException. 
Also tried to make logging more similar across the 2 workers.