### PR TITLE
Aggregate statsManager not found error logs

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunNetTest.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunNetTest.kt
@@ -322,6 +322,8 @@ class RunNetTest(
     private fun TaskEvent.Log.getKnownException() =
         if (message.startsWith("cannot submit measurement")) {
             CannotSubmitMeasurement()
+        } else if (message.startsWith("statsManager") && message.contains("not found:")) {
+            StatsManagerNotFoundError()
         } else {
             null
         }
@@ -338,4 +340,6 @@ class RunNetTest(
     inner class BugJsonDump(value: TaskEventResult.Value?) : Failure(null, value)
 
     inner class CannotSubmitMeasurement : Failure(null, null)
+
+    inner class StatsManagerNotFoundError : Failure(null, null)
 }


### PR DESCRIPTION
The goal is too aggregate all these error logs we're getting from the engine: https://ooni.sentry.io/issues/?project=4508325650235392&query=%21is%3Aarchived%20is%3Aunresolved%20not%20found&referrer=issue-list&sort=freq&statsPeriod=14d&viewId=71246