### PR TITLE
Accessibility improvements

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/run/RunScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/run/RunScreen.kt
@@ -298,7 +298,8 @@ private fun DescriptorItem(
                     } else {
                         Res.string.Common_Expand
                     },
-                ),
+                ) + " " + descriptor.title(),
+                modifier = Modifier.padding(2.dp),
             )
         }
     }
@@ -321,7 +322,7 @@ fun TestItem(
                 role = Role.Checkbox,
                 enabled = enabled,
             )
-            .padding(horizontal = 16.dp, vertical = 10.dp),
+            .padding(horizontal = 16.dp, vertical = 12.dp),
     ) {
         Checkbox(
             checked = testItem.isSelected,

--- a/composeApp/src/ooniMain/kotlin/org/ooni/probe/ui/Colors.kt
+++ b/composeApp/src/ooniMain/kotlin/org/ooni/probe/ui/Colors.kt
@@ -2,9 +2,9 @@ package org.ooni.probe.ui
 
 import androidx.compose.ui.graphics.Color
 
-val primaryLight = Color(0xFF0588CB)
+val primaryLight = Color(0xFF0579B3)
 val onPrimaryLight = Color(0xFFFFFFFF)
-val primaryContainerLight = Color(0xFF0588CB)
+val primaryContainerLight = Color(0xFF0579B3)
 val onPrimaryContainerLight = Color(0xFFFFFFFF)
 val secondaryLight = Color(0xFF2D638B)
 val onSecondaryLight = Color(0xFFFFFFFF)


### PR DESCRIPTION
Fix the issues I found using the Accessibility Scanner for our main screens:
- Lack of contrast between our primary and primaryContainer colors and the background. Contrast is now `4.54:1` between #0579B3 and #F7F9FF.
- Duplicated content description for the collapse/expand buttons on the Run screen
- Touch targets too small for the collapse/expand buttons and the test items on the Run screen
 