### PR TITLE
Re-create DB if older than V5

### DIFF
--- a/composeApp/src/commonMain/sqldelight/migrations/4.sqm
+++ b/composeApp/src/commonMain/sqldelight/migrations/4.sqm
@@ -1,0 +1,13 @@
+-- Re-create DB if older than version 5
+
+DROP TABLE IF EXISTS Measurement;
+DROP TABLE IF EXISTS Result;
+DROP TABLE IF EXISTS Network;
+DROP TABLE IF EXISTS Url;
+DROP TABLE IF EXISTS TestDescriptor;
+
+CREATE TABLE `TestDescriptor`(`runId` INTEGER, `name` TEXT, `short_description` TEXT, `description` TEXT, `author` TEXT, `nettests` TEXT, `name_intl` TEXT, `short_description_intl` TEXT, `description_intl` TEXT, `icon` TEXT, `color` TEXT, `animation` TEXT, `expiration_date` INTEGER, `date_created` INTEGER, `date_updated` INTEGER, `revision` TEXT, `previous_revision` TEXT, `is_expired` INTEGER, `auto_update` INTEGER, PRIMARY KEY(`runId`));
+CREATE TABLE `Network`(`id` INTEGER PRIMARY KEY AUTOINCREMENT, `network_name` TEXT, `ip` TEXT, `asn` TEXT, `country_code` TEXT, `network_type` TEXT);
+CREATE TABLE `Result`(`id` INTEGER PRIMARY KEY AUTOINCREMENT, `test_group_name` TEXT, `start_time` INTEGER, `is_viewed` INTEGER, `is_done` INTEGER, `data_usage_up` INTEGER, `data_usage_down` INTEGER, `failure_msg` TEXT, `network_id` INTEGER, `descriptor_runId` INTEGER REFERENCES TestDescriptor (`runId`), FOREIGN KEY(`network_id`) REFERENCES `Network`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION);
+CREATE TABLE `Url`(`id` INTEGER PRIMARY KEY AUTOINCREMENT, `url` TEXT, `category_code` TEXT, `country_code` TEXT);
+CREATE TABLE `Measurement`(`id` INTEGER PRIMARY KEY AUTOINCREMENT, `test_name` TEXT, `start_time` INTEGER, `runtime` REAL, `is_done` INTEGER, `is_uploaded` INTEGER, `is_failed` INTEGER, `failure_msg` TEXT, `is_upload_failed` INTEGER, `upload_failure_msg` TEXT, `is_rerun` INTEGER, `report_id` TEXT, `is_anomaly` INTEGER, `test_keys` TEXT, `url_id` INTEGER, `result_id` INTEGER, `rerun_network` TEXT, FOREIGN KEY(`url_id`) REFERENCES `Url`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION, FOREIGN KEY(`result_id`) REFERENCES `Result`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION);


### PR DESCRIPTION
I copied the `CREATE TABLE` statements from the `5.db` file we have a reference. Then `4.sqm` migration runs when migrating from v4 to v5.