### PR TITLE
Remove DependencyInfoBlock

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -219,8 +219,8 @@ android {
     dependenciesInfo {
         // Disables dependency metadata when building APKs.
         includeInApk = false
-        // Disables dependency metadata when building Android App Bundles.
-        includeInBundle = false
+        // Keeps dependency metadata when building Android App Bundles.
+        includeInBundle = true
     }
     testOptions {
         execution = "ANDROIDX_TEST_ORCHESTRATOR"

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -216,6 +216,12 @@ android {
         "fullImplementation"(libs.bundles.full.android)
         androidTestUtil(libs.android.orchestrator)
     }
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
     testOptions {
         execution = "ANDROIDX_TEST_ORCHESTRATOR"
     }


### PR DESCRIPTION
```
$ apksigtool parse --json OONIProbe-Android-5.0.2-fdroid.apk | jq -r '.pairs[].value._type'
APKSignatureSchemeBlock
DependencyInfoBlock
VerityPaddingBlock
```

We find that there is a `DependencyInfoBlock` in your APK.

It's a [Signing block](https://source.android.com/docs/security/features/apksigning/v2#apk-signing-block) added by AGP and encrypted with the Google public key so it can't be read by anyone else except Google. You can read more about it [here](https://gitlab.com/fdroid/admin/-/issues/367) and [here](https://gitlab.com/fdroid/fdroidserver/-/issues/1056).

While OONI Probe is not built reproducible in F-Droid, we rebuild apps and try to fix issues: https://verification.f-droid.org so more apps are reproducible in general.

related: https://f-droid.org/docs/Inclusion_How-To/#reproducible-builds

related: https://gitlab.com/fdroid/fdroiddata/-/merge_requests/19716