### PR TITLE
Fix IllegalArgumentException due to duplicated descriptor key

### DIFF
--- a/composeApp/src/commonMain/sqldelight/org/ooni/probe/data/TestDescriptor.sq
+++ b/composeApp/src/commonMain/sqldelight/org/ooni/probe/data/TestDescriptor.sq
@@ -71,23 +71,15 @@ selectAll:
 SELECT * FROM TestDescriptor ORDER BY runId;
 
 selectLatest:
-WITH latest AS (
-    SELECT runId, MAX(date_updated) AS last_date_updated FROM TestDescriptor GROUP BY runId
-)
-SELECT * FROM TestDescriptor
-WHERE runId IN (SELECT runId FROM latest)
-AND date_updated IN (SELECT last_date_updated FROM latest)
+SELECT * FROM TestDescriptor TD1
+WHERE TD1.revision = (SELECT MAX(TD2.revision) FROM TestDescriptor TD2 WHERE TD2.runId = TD1.runId)
 ORDER BY runId;
 
 selectLatestByRunIds:
-WITH latest AS (
-    SELECT runId, MAX(date_updated) AS last_date_updated FROM TestDescriptor
-    WHERE runId IN ?
-    GROUP BY runId
-)
-SELECT * FROM TestDescriptor
-WHERE runId IN (SELECT runId FROM latest)
-AND date_updated IN (SELECT last_date_updated FROM latest);
+SELECT * FROM TestDescriptor TD1
+WHERE TD1.revision = (SELECT MAX(TD2.revision) FROM TestDescriptor TD2 WHERE TD2.runId = TD1.runId)
+AND TD1.runId IN ?
+ORDER BY runId;
 
 deleteByRunId:
 DELETE FROM TestDescriptor WHERE runId = ?;

--- a/composeApp/src/commonTest/kotlin/org/ooni/probe/data/repositories/TestDescriptorRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/probe/data/repositories/TestDescriptorRepositoryTest.kt
@@ -113,6 +113,22 @@ class TestDescriptorRepositoryTest {
         }
 
     @Test
+    fun listLatestWithSameDateUpdated() =
+        runTest {
+            val model1 = DescriptorFactory.buildInstalledModel(
+                id = InstalledTestDescriptorModel.Id("A"),
+                revision = 0,
+                dateUpdated = now().toLocalDateTime(),
+            )
+            val model2 = model1.copy(revision = 1)
+            subject.createOrIgnore(listOf(model1, model2))
+
+            val latest = subject.listLatest().first()
+            assertEquals(1, latest.size)
+            assertContains(latest, model2)
+        }
+
+    @Test
     fun listLatestByRunIds() =
         runTest {
             val modelA1 = DescriptorFactory.buildInstalledModel(

--- a/composeApp/src/dwMain/kotlin/org/ooni/probe/domain/OrganizationPreferenceDefaults.kt
+++ b/composeApp/src/dwMain/kotlin/org/ooni/probe/domain/OrganizationPreferenceDefaults.kt
@@ -1,6 +1,5 @@
 package org.ooni.probe.domain
 
-import org.ooni.probe.data.models.PreferenceItem
 import org.ooni.probe.data.models.SettingsKey
 
 fun organizationPreferenceDefaults(): List<Pair<SettingsKey, Any>> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ sqldelight-android = { module = "app.cash.sqldelight:android-driver", version.re
 sqldelight-native = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 
 # Files
-okio = { module = "com.squareup.okio:okio", version = "3.9.1" }
+okio = { module = "com.squareup.okio:okio", version = "3.10.2" }
 
 # Lottie animations
 kottie = { module = "io.github.alexzhirkevich:compottie", version = "2.0.0-rc01" } # 2.0.0 not supported yet


### PR DESCRIPTION
Closes #495 

The SQL queries weren't behaving properly because I forgot there was a scenario where the date updated could be the same between 2 different revisions.

@hellais If you know any way we could avoid the nested query let me know. This is a table without a lot of rows, but it would be nice to optimize.