### PR TITLE
Delete not-uploaded measurements with missing report files

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/data/repositories/MeasurementRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/data/repositories/MeasurementRepository.kt
@@ -115,6 +115,12 @@ class MeasurementRepository(
         }
     }
 
+    suspend fun deleteById(measurementId: MeasurementModel.Id) {
+        withContext(backgroundContext) {
+            database.measurementQueries.deleteById(measurementId.value)
+        }
+    }
+
     private fun Measurement.toModel(): MeasurementModel? {
         return MeasurementModel(
             id = MeasurementModel.Id(id),

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
@@ -398,6 +398,7 @@ class Dependencies(
             readFile = readFile,
             deleteFiles = deleteFiles,
             updateMeasurement = measurementRepository::createOrUpdate,
+            deleteMeasurementById = measurementRepository::deleteById,
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/UploadMissingMeasurements.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/UploadMissingMeasurements.kt
@@ -19,6 +19,7 @@ class UploadMissingMeasurements(
     private val readFile: ReadFile,
     private val deleteFiles: DeleteFiles,
     private val updateMeasurement: suspend (MeasurementModel) -> Unit,
+    private val deleteMeasurementById: suspend (MeasurementModel.Id) -> Unit,
 ) {
     operator fun invoke(resultId: ResultModel.Id? = null): Flow<State> =
         channelFlow {
@@ -46,6 +47,7 @@ class UploadMissingMeasurements(
                 if (report.isNullOrBlank()) {
                     Logger.w("Missing or empty measurement report file")
                     failedToUpload++
+                    measurement.id?.let { deleteMeasurementById(it) }
                     return@forEach
                 }
 

--- a/composeApp/src/commonMain/sqldelight/org/ooni/probe/data/Measurement.sq
+++ b/composeApp/src/commonMain/sqldelight/org/ooni/probe/data/Measurement.sq
@@ -54,6 +54,9 @@ WHERE Measurement.result_id IN (
     WHERE Result.descriptor_runId = ?
 );
 
+deleteById:
+DELETE FROM Measurement WHERE Measurement.id = ?;
+
 selectLastInsertedRowId:
 SELECT last_insert_rowid();
 

--- a/composeApp/src/commonTest/kotlin/org/ooni/probe/data/repositories/MeasurementRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/probe/data/repositories/MeasurementRepositoryTest.kt
@@ -73,4 +73,17 @@ class MeasurementRepositoryTest {
                 assertEquals(true, isDone)
             }
         }
+
+    @Test
+    fun createAndDelete() =
+        runTest {
+            val model = MeasurementModelFactory.build(id = null)
+            val modelId = subject.createOrUpdate(model)
+
+            assertEquals(1, subject.list().first().size)
+
+            subject.deleteById(modelId)
+
+            assertEquals(0, subject.list().first().size)
+        }
 }

--- a/composeApp/src/commonTest/kotlin/org/ooni/probe/domain/UploadMissingMeasurementsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/probe/domain/UploadMissingMeasurementsTest.kt
@@ -36,6 +36,7 @@ class UploadMissingMeasurementsTest {
                 readFile = { "{}" },
                 deleteFiles = { },
                 updateMeasurement = { newModel = it },
+                deleteMeasurementById = { },
             )
 
             val results = mutableListOf<UploadMissingMeasurements.State>()
@@ -62,6 +63,7 @@ class UploadMissingMeasurementsTest {
                 readFile = { "{}" },
                 deleteFiles = { },
                 updateMeasurement = { newModel = it },
+                deleteMeasurementById = { },
             )
 
             val results = mutableListOf<UploadMissingMeasurements.State>()
@@ -80,12 +82,14 @@ class UploadMissingMeasurementsTest {
                 id = MeasurementModel.Id(Random.nextLong().absoluteValue),
             )
             var updateMeasurementCalled = false
+            var deleteMeasurementCalled = false
             val subject = UploadMissingMeasurements(
                 getMeasurementsNotUploaded = { flowOf(listOf(model)) },
                 submitMeasurement = { Failure(Engine.MkException(Exception("failed"))) },
                 readFile = { "" },
                 deleteFiles = { },
                 updateMeasurement = { updateMeasurementCalled = true },
+                deleteMeasurementById = { deleteMeasurementCalled = true },
             )
 
             val results = mutableListOf<UploadMissingMeasurements.State>()
@@ -95,5 +99,6 @@ class UploadMissingMeasurementsTest {
             assertEquals(UploadMissingMeasurements.State.Uploading(0, 0, 1), results[1])
             assertEquals(UploadMissingMeasurements.State.Finished(0, 1, 1), results[2])
             assertFalse(updateMeasurementCalled)
+            assertTrue(deleteMeasurementCalled)
         }
 }


### PR DESCRIPTION
Right now those are pilling up in the app. We'll keep reporting to Sentry, but delete them afterwards.