### PR TITLE
Handle invalid test_keys values. Do not store empty test_keys map.

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/data/repositories/MeasurementRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/data/repositories/MeasurementRepository.kt
@@ -2,6 +2,7 @@ package org.ooni.probe.data.repositories
 
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -174,7 +175,7 @@ class MeasurementRepository(
             id = MeasurementModel.Id(id),
             resultId = result_id?.let(ResultModel::Id) ?: return null,
             testName = test_name,
-            testKeys = test_keys?.let { json.decodeFromString<TestKeys>(it) },
+            testKeys = test_keys?.let(::decodeTestKeys),
             descriptorName = descriptor_name,
             descriptorRunId = descriptor_runId?.let(InstalledTestDescriptorModel::Id),
         )
@@ -185,9 +186,19 @@ class MeasurementRepository(
             id = MeasurementModel.Id(id),
             resultId = result_id?.let(ResultModel::Id) ?: return null,
             testName = test_name,
-            testKeys = test_keys?.let { json.decodeFromString<TestKeys>(it) },
+            testKeys = test_keys?.let(::decodeTestKeys),
             descriptorName = descriptor_name,
             descriptorRunId = descriptor_runId?.let(InstalledTestDescriptorModel::Id),
         )
+    }
+
+    private fun decodeTestKeys(value: String): TestKeys? {
+        if (value == "null") return null // Due to a past bug
+        return try {
+            json.decodeFromString<TestKeys>(value)
+        } catch (e: Exception) {
+            Logger.e("Invalid stored test_keys", e)
+            null
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunNetTest.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunNetTest.kt
@@ -179,7 +179,11 @@ class RunNetTest(
                         event.result.testKeys?.let {
                             val testKeys = extractTestKeysPropertiesToJson(it)
                             measurement = measurement.copy(
-                                testKeys = json.encodeToString(testKeys),
+                                testKeys = if (testKeys.isEmpty()) {
+                                    null
+                                } else {
+                                    json.encodeToString(testKeys)
+                                },
                             )
                         }
 


### PR DESCRIPTION
Fixes https://ooni.sentry.io/issues/6352293866/?project=4508325642764288&query=%21is%3Aarchived%20is%3Aunresolved%20installerStore%3A%5Bcom.huawei.appmarket%2Ccom.android.vending%5D&referrer=issue-stream&sort=freq&statsPeriod=7d&stream_index=8