### PR TITLE
Fix messaging test keys evaluation

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/EvaluateMeasurementKeys.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/EvaluateMeasurementKeys.kt
@@ -43,7 +43,7 @@ fun evaluateMeasurementKeys(
         TestType.Signal ->
             MeasurementKeysResult(
                 isFailed = keys?.signalBackendStatus?.isEmpty() != false,
-                isAnomaly = keys?.signalBackendStatus == TestKeys.BLOCKED_VALUE,
+                isAnomaly = keys?.signalBackendStatus.isBlocked,
             )
 
         TestType.Telegram ->
@@ -51,9 +51,9 @@ fun evaluateMeasurementKeys(
                 isFailed = keys?.telegramHttpBlocking == null ||
                     keys.telegramTcpBlocking == null ||
                     keys.telegramWebStatus == null,
-                isAnomaly = keys?.facebookTcpBlocking == true ||
-                    keys?.facebookDnsBlocking == true ||
-                    keys?.telegramWebStatus == TestKeys.BLOCKED_VALUE,
+                isAnomaly = keys?.telegramHttpBlocking == true ||
+                    keys?.telegramTcpBlocking == true ||
+                    keys?.telegramWebStatus.isBlocked,
             )
 
         TestType.Tor ->
@@ -87,11 +87,14 @@ fun evaluateMeasurementKeys(
                 isFailed = keys?.whatsappEndpointsStatus == null ||
                     keys.whatsappWebStatus == null ||
                     keys.registrationServerStatus == null,
-                isAnomaly = keys?.whatsappEndpointsStatus == TestKeys.BLOCKED_VALUE ||
-                    keys?.whatsappWebStatus == TestKeys.BLOCKED_VALUE ||
-                    keys?.registrationServerStatus == TestKeys.BLOCKED_VALUE,
+                isAnomaly = keys?.whatsappEndpointsStatus.isBlocked ||
+                    keys?.whatsappWebStatus.isBlocked ||
+                    keys?.registrationServerStatus.isBlocked,
             )
     }
+
+private val String?.isBlocked
+    get() = equals(TestKeys.BLOCKED_VALUE, ignoreCase = true)
 
 fun extractTestKeysPropertiesToJson(testKeys: TestKeys): Map<String, Map<String, Double?>?> {
     return mapOf(

--- a/composeApp/src/commonTest/kotlin/org/ooni/probe/domain/EvaluateMeasurementKeysTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/probe/domain/EvaluateMeasurementKeysTest.kt
@@ -1,0 +1,92 @@
+package org.ooni.probe.domain
+
+import kotlinx.coroutines.test.runTest
+import org.ooni.engine.models.TestKeys
+import org.ooni.engine.models.TestType
+import org.ooni.probe.data.models.MeasurementKeysResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EvaluateMeasurementKeysTest {
+    @Test
+    fun telegram() =
+        runTest {
+            assertEquals(
+                MeasurementKeysResult(
+                    isFailed = false,
+                    isAnomaly = false,
+                ),
+                evaluateMeasurementKeys(
+                    TestType.Telegram,
+                    TestKeys(
+                        telegramWebStatus = "ok",
+                        telegramTcpBlocking = false,
+                        telegramHttpBlocking = false,
+                    ),
+                ),
+            )
+            assertEquals(
+                MeasurementKeysResult(
+                    isFailed = false,
+                    isAnomaly = true,
+                ),
+                evaluateMeasurementKeys(
+                    TestType.Telegram,
+                    TestKeys(
+                        telegramWebStatus = "blocked",
+                        telegramTcpBlocking = false,
+                        telegramHttpBlocking = false,
+                    ),
+                ),
+            )
+            assertEquals(
+                MeasurementKeysResult(
+                    isFailed = true,
+                    isAnomaly = false,
+                ),
+                evaluateMeasurementKeys(
+                    TestType.Telegram,
+                    TestKeys(
+                        telegramWebStatus = null,
+                        telegramTcpBlocking = false,
+                        telegramHttpBlocking = false,
+                    ),
+                ),
+            )
+        }
+
+    @Test
+    fun signal() =
+        runTest {
+            assertEquals(
+                MeasurementKeysResult(
+                    isFailed = true,
+                    isAnomaly = false,
+                ),
+                evaluateMeasurementKeys(
+                    TestType.Signal,
+                    TestKeys(),
+                ),
+            )
+            assertEquals(
+                MeasurementKeysResult(
+                    isFailed = false,
+                    isAnomaly = true,
+                ),
+                evaluateMeasurementKeys(
+                    TestType.Signal,
+                    TestKeys(signalBackendStatus = "blocked"),
+                ),
+            )
+            assertEquals(
+                MeasurementKeysResult(
+                    isFailed = false,
+                    isAnomaly = false,
+                ),
+                evaluateMeasurementKeys(
+                    TestType.Signal,
+                    TestKeys(signalBackendStatus = "ok"),
+                ),
+            )
+        }
+}


### PR DESCRIPTION
We were using the wrong keys for Telegram. And on Explorer I'm seeing lowercase "blocked", so I'm making sure our string checks ignore case.