### PR TITLE
Fix Android isBatteryCharging and auto-run notifications

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/ooni/probe/background/DescriptorUpdateWorker.kt
+++ b/composeApp/src/androidMain/kotlin/org/ooni/probe/background/DescriptorUpdateWorker.kt
@@ -16,9 +16,8 @@ import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.encodeToString
-import ooniprobe.composeapp.generated.resources.Dashboard_Running_Running
-import ooniprobe.composeapp.generated.resources.Notification_ChannelName
+import ooniprobe.composeapp.generated.resources.Dashboard_Progress_UpdateLink_Label
+import ooniprobe.composeapp.generated.resources.Notification_UpdateChannelName
 import ooniprobe.composeapp.generated.resources.Res
 import org.jetbrains.compose.resources.getString
 import org.ooni.probe.AndroidApplication
@@ -68,11 +67,7 @@ class DescriptorUpdateWorker(
 
         return try {
             val descriptors = getDescriptors() ?: return Result.failure()
-            if (descriptors.isEmpty()) {
-                Logger.i("DescriptorUpdateWorker: Skipping, no descriptors to update")
-            } else {
-                dependencies.getDescriptorUpdate.invoke(descriptors)
-            }
+            dependencies.getDescriptorUpdate.invoke(descriptors)
             Result.success(buildWorkData(descriptors.map { it.id }))
         } catch (e: CancellationException) {
             if (isStopped) {
@@ -112,8 +107,8 @@ class DescriptorUpdateWorker(
             notificationManager.createNotificationChannel(
                 NotificationChannel(
                     NOTIFICATION_CHANNEL_ID,
-                    getString(Res.string.Notification_ChannelName),
-                    NotificationManager.IMPORTANCE_DEFAULT,
+                    getString(Res.string.Notification_UpdateChannelName),
+                    NotificationManager.IMPORTANCE_LOW,
                 ),
             )
         }
@@ -122,7 +117,7 @@ class DescriptorUpdateWorker(
     private suspend fun buildNotification(): Notification {
         return NotificationCompat.Builder(applicationContext, NOTIFICATION_CHANNEL_ID)
             .setSmallIcon(R.drawable.notification_icon)
-            .setContentTitle(getString(Res.string.Dashboard_Running_Running))
+            .setContentTitle(getString(Res.string.Dashboard_Progress_UpdateLink_Label))
             .setAutoCancel(false)
             .build()
     }

--- a/composeApp/src/androidMain/kotlin/org/ooni/probe/background/RunWorker.kt
+++ b/composeApp/src/androidMain/kotlin/org/ooni/probe/background/RunWorker.kt
@@ -60,18 +60,7 @@ class RunWorker(
     override suspend fun getForegroundInfo(): ForegroundInfo {
         buildNotificationChannelIfNeeded()
         val notification = buildNotification(RunBackgroundState.RunningTests())
-        return if (Build.VERSION.SDK_INT >= 29) {
-            ForegroundInfo(
-                NOTIFICATION_ID,
-                notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
-            )
-        } else {
-            ForegroundInfo(
-                NOTIFICATION_ID,
-                notification,
-            )
-        }
+        return buildForegroundInfo(notification)
     }
 
     override suspend fun doWork(): Result {
@@ -124,9 +113,7 @@ class RunWorker(
                     is RunBackgroundState.Stopping -> buildStoppingNotification()
                 }
                 if (notification != null) {
-                    notificationManager.notify(NOTIFICATION_ID, notification)
-                } else {
-                    notificationManager.cancel(NOTIFICATION_ID)
+                    setForeground(buildForegroundInfo(notification))
                 }
             }
     }
@@ -161,6 +148,21 @@ class RunWorker(
                     getString(Res.string.Notification_ChannelName),
                     NotificationManager.IMPORTANCE_LOW,
                 ),
+            )
+        }
+    }
+
+    private fun buildForegroundInfo(notification: Notification): ForegroundInfo {
+        return if (Build.VERSION.SDK_INT >= 29) {
+            ForegroundInfo(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            ForegroundInfo(
+                NOTIFICATION_ID,
+                notification,
             )
         }
     }
@@ -207,6 +209,7 @@ class RunWorker(
                 .setPriority(NotificationCompat.PRIORITY_LOW)
                 .setSound(null)
                 .setVibrate(null)
+                .setOnlyAlertOnce(true)
                 .setLights(0, 0, 0)
                 .setColor(primaryLight.toArgb())
                 .setContentIntent(openAppIntent),

--- a/composeApp/src/commonMain/composeResources/values-ms/.gitignore
+++ b/composeApp/src/commonMain/composeResources/values-ms/.gitignore
@@ -1,0 +1,2 @@
+
+strings-organization.xml

--- a/composeApp/src/commonMain/composeResources/values/strings-common.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings-common.xml
@@ -325,6 +325,7 @@
     <string name="OONIRun_Run">Run</string>
 
     <string name="Notification_ChannelName">Testing</string>
+    <string name="Notification_UpdateChannelName">Link Updates</string>
     <string name="Notification_StopTest">Stop test</string>
 
     <string name="Common_Back">Back</string>

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/background/RunBackgroundTask.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/background/RunBackgroundTask.kt
@@ -116,6 +116,7 @@ class RunBackgroundTask(
             getRunBackgroundState()
                 .takeWhile { state ->
                     state is RunBackgroundState.RunningTests ||
+                        state is RunBackgroundState.UploadingMissingResults ||
                         state is RunBackgroundState.Stopping ||
                         (state is RunBackgroundState.Idle && !testStarted)
                 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/descriptors/FetchDescriptorsUpdates.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/descriptors/FetchDescriptorsUpdates.kt
@@ -16,11 +16,16 @@ class FetchDescriptorsUpdates(
     private val updateState: ((DescriptorsUpdateState) -> DescriptorsUpdateState) -> Unit,
 ) {
     suspend operator fun invoke(descriptors: List<InstalledTestDescriptorModel>) {
+        if (descriptors.isEmpty()) {
+            Logger.i("Skipping, no descriptors to update")
+        }
+
         updateState {
             DescriptorsUpdateState(
                 operationState = DescriptorUpdateOperationState.FetchingUpdates,
             )
         }
+
         val fetchResults = coroutineScope {
             descriptors.map { descriptor ->
                 async { descriptor to fetchDescriptor(descriptor.id.value) }


### PR DESCRIPTION
The `RunBackgroundTask.kt` changes fix the auto-run notification not updating.

I updated the `checkBatteryCharging` code to the code provided by the reference. But please test it too @aanorbel.

I also improved the descriptor update notification and notification channel. That introduced a new string for translations.

---

@agrabeli Can you approve the new "Link Updates" string we added? It's only visible through app settings. It's to distinguish notifications from our background tests, and when we're just updating the Links (once per day). Users can pick whether to see or not those notifications. The channel name needs to be short.

<img src="https://github.com/user-attachments/assets/7ce0cd80-f8f0-4990-9a7f-828e98040b05" width=300/>
