### PR TITLE
Check for ignore battery on app start and auto-run enable

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings-common.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings-common.xml
@@ -317,7 +317,8 @@
     <string name="Modal_Error_CantDownloadURLs">Unable to download URL list. Please try again.</string>
     <string name="Modal_CustomURL_Title_NotSaved">Are you sure?</string>
     <string name="Modal_CustomURL_NotSaved">Your URLs will not be saved when you leave this screen. Are you sure you want to leave this screen?</string>
-    <string name="Modal_Autorun_BatteryOptimization">OONI Probe cannot run automatically without battery optimization. Do you want to try again?</string>
+    <string name="Modal_Autorun_BatteryOptimization">The application cannot run tests automatically without battery optimization. Do you want to try again?</string>
+    <string name="Modal_Autorun_BatteryOptimization_Reminder">The application needs permission to run tests automatically in the background.</string>
     <string name="Modal_EnableNotifications_Title">Get updates on internet censorship</string>
 
     <!-- Common / Others -->

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/config/BatteryOptimization.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/config/BatteryOptimization.kt
@@ -6,7 +6,7 @@ interface BatteryOptimization {
     val isIgnoring: Boolean
         get() = throw IllegalStateException("Battery Optimization not supported")
 
-    fun requestIgnore(onResponse: (Boolean) -> Unit) {
+    fun requestIgnore(onResponse: (Boolean) -> Unit = {}) {
         throw IllegalStateException("Battery Optimization not supported")
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
@@ -483,6 +483,8 @@ class Dependencies(
         startDescriptorsUpdates = startDescriptorsUpdate,
         dismissDescriptorsUpdateNotice = dismissDescriptorReviewNotice::invoke,
         observeDescriptorUpdateState = descriptorUpdateStateManager::observe,
+        getAutoRunSettings = getAutoRunSettings::invoke,
+        batteryOptimization = batteryOptimization,
     )
 
     fun descriptorViewModel(
@@ -607,8 +609,9 @@ class Dependencies(
         categoryKey = categoryKey,
         onBack = onBack,
         goToSettingsForCategory = goToSettingsForCategory,
-        preferenceManager = preferenceRepository,
+        preferenceRepository = preferenceRepository,
         getSettings = getSettings::invoke,
+        batteryOptimization = batteryOptimization,
     )
 
     fun settingsViewModel(goToSettingsForCategory: (PreferenceCategoryKey) -> Unit) =

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/ObserveAndConfigureAutoRun.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/ObserveAndConfigureAutoRun.kt
@@ -10,9 +10,9 @@ import kotlin.coroutines.CoroutineContext
 class ObserveAndConfigureAutoRun(
     private val backgroundContext: CoroutineContext,
     private val configureAutoRun: suspend (AutoRunParameters) -> Unit,
-    private val getAutoRunSettings: suspend () -> Flow<AutoRunParameters>,
+    private val getAutoRunSettings: () -> Flow<AutoRunParameters>,
 ) {
-    suspend operator fun invoke() =
+    operator fun invoke() =
         getAutoRunSettings()
             .onEach { configureAutoRun(it) }
             .launchIn(CoroutineScope(backgroundContext))

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/dashboard/DashboardScreen.kt
@@ -39,6 +39,7 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.ooni.probe.data.models.DescriptorUpdateOperationState
+import org.ooni.probe.ui.shared.IgnoreBatteryOptimizationDialog
 import org.ooni.probe.ui.shared.TestRunErrorMessages
 import org.ooni.probe.ui.shared.UpdateProgressStatus
 import org.ooni.probe.ui.shared.isHeightCompact
@@ -136,6 +137,13 @@ fun DashboardScreen(
         errors = state.testRunErrors,
         onErrorDisplayed = { onEvent(DashboardViewModel.Event.ErrorDisplayed(it)) },
     )
+
+    if (state.showIgnoreBatteryOptimizationNotice) {
+        IgnoreBatteryOptimizationDialog(
+            onAccepted = { onEvent(DashboardViewModel.Event.IgnoreBatteryOptimizationAccepted) },
+            onDismissed = { onEvent(DashboardViewModel.Event.IgnoreBatteryOptimizationDismissed) },
+        )
+    }
 
     LaunchedEffect(Unit) {
         onEvent(DashboardViewModel.Event.Start)

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/dashboard/DashboardViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/dashboard/DashboardViewModel.kt
@@ -11,13 +11,15 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.update
+import org.ooni.probe.config.BatteryOptimization
+import org.ooni.probe.data.models.AutoRunParameters
 import org.ooni.probe.data.models.Descriptor
 import org.ooni.probe.data.models.DescriptorType
+import org.ooni.probe.data.models.DescriptorUpdateOperationState
 import org.ooni.probe.data.models.DescriptorsUpdateState
 import org.ooni.probe.data.models.InstalledTestDescriptorModel
 import org.ooni.probe.data.models.RunBackgroundState
 import org.ooni.probe.data.models.TestRunError
-import org.ooni.probe.data.models.DescriptorUpdateOperationState
 
 class DashboardViewModel(
     goToOnboarding: () -> Unit,
@@ -34,6 +36,8 @@ class DashboardViewModel(
     observeDescriptorUpdateState: () -> Flow<DescriptorsUpdateState>,
     startDescriptorsUpdates: suspend (List<InstalledTestDescriptorModel>?) -> Unit,
     dismissDescriptorsUpdateNotice: () -> Unit,
+    getAutoRunSettings: () -> Flow<AutoRunParameters>,
+    batteryOptimization: BatteryOptimization,
 ) : ViewModel() {
     private val events = MutableSharedFlow<Event>(extraBufferCapacity = 1)
 
@@ -44,6 +48,18 @@ class DashboardViewModel(
         getFirstRun()
             .take(1)
             .onEach { firstRun -> if (firstRun) goToOnboarding() }
+            .launchIn(viewModelScope)
+
+        getAutoRunSettings()
+            .take(1)
+            .onEach { autoRunParameters ->
+                if (autoRunParameters is AutoRunParameters.Enabled &&
+                    batteryOptimization.isSupported &&
+                    !batteryOptimization.isIgnoring
+                ) {
+                    _state.update { it.copy(showIgnoreBatteryOptimizationNotice = true) }
+                }
+            }
             .launchIn(viewModelScope)
 
         observeDescriptorUpdateState()
@@ -139,6 +155,21 @@ class DashboardViewModel(
             .filterIsInstance<Event.CancelUpdatesClicked>()
             .onEach { dismissDescriptorsUpdateNotice() }
             .launchIn(viewModelScope)
+
+        events
+            .filterIsInstance<Event.IgnoreBatteryOptimizationAccepted>()
+            .onEach {
+                _state.update { it.copy(showIgnoreBatteryOptimizationNotice = false) }
+                if (batteryOptimization.isSupported && !batteryOptimization.isIgnoring) {
+                    batteryOptimization.requestIgnore()
+                }
+            }
+            .launchIn(viewModelScope)
+
+        events
+            .filterIsInstance<Event.IgnoreBatteryOptimizationDismissed>()
+            .onEach { _state.update { it.copy(showIgnoreBatteryOptimizationNotice = false) } }
+            .launchIn(viewModelScope)
     }
 
     fun onEvent(event: Event) {
@@ -158,6 +189,7 @@ class DashboardViewModel(
         val showVpnWarning: Boolean = false,
         val availableUpdates: List<InstalledTestDescriptorModel> = emptyList(),
         val descriptorsUpdateOperationState: DescriptorUpdateOperationState = DescriptorUpdateOperationState.Idle,
+        val showIgnoreBatteryOptimizationNotice: Boolean = false,
     ) {
         val isRefreshing: Boolean
             get() = descriptorsUpdateOperationState == DescriptorUpdateOperationState.FetchingUpdates
@@ -183,5 +215,9 @@ class DashboardViewModel(
         data object ReviewUpdatesClicked : Event
 
         data object CancelUpdatesClicked : Event
+
+        data object IgnoreBatteryOptimizationAccepted : Event
+
+        data object IgnoreBatteryOptimizationDismissed : Event
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/settings/category/SettingsCategoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/settings/category/SettingsCategoryScreen.kt
@@ -49,6 +49,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.ooni.probe.data.models.PreferenceItemType
 import org.ooni.probe.data.models.SettingsCategoryItem
 import org.ooni.probe.data.models.SettingsKey
+import org.ooni.probe.ui.shared.IgnoreBatteryOptimizationDialog
 import org.ooni.probe.ui.shared.TopBar
 
 @Composable
@@ -153,6 +154,17 @@ fun SettingsCategoryScreen(
                 }
             }
         }
+    }
+
+    if (state.showIgnoreBatteryOptimizationNotice) {
+        IgnoreBatteryOptimizationDialog(
+            onAccepted = {
+                onEvent(SettingsCategoryViewModel.Event.IgnoreBatteryOptimizationAccepted)
+            },
+            onDismissed = {
+                onEvent(SettingsCategoryViewModel.Event.IgnoreBatteryOptimizationDismissed)
+            },
+        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/settings/category/SettingsCategoryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/settings/category/SettingsCategoryViewModel.kt
@@ -6,24 +6,29 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.runningFold
 import kotlinx.coroutines.flow.update
+import org.ooni.probe.config.BatteryOptimization
 import org.ooni.probe.data.models.PreferenceCategoryKey
 import org.ooni.probe.data.models.SettingsCategoryItem
 import org.ooni.probe.data.models.SettingsKey
 import org.ooni.probe.data.repositories.PreferenceRepository
+import org.ooni.probe.ui.dashboard.DashboardViewModel.Event
 
 class SettingsCategoryViewModel(
     categoryKey: String,
     goToSettingsForCategory: (PreferenceCategoryKey) -> Unit,
     onBack: () -> Unit,
     getSettings: () -> Flow<List<SettingsCategoryItem>>,
-    preferenceManager: PreferenceRepository,
+    preferenceRepository: PreferenceRepository,
+    batteryOptimization: BatteryOptimization,
 ) : ViewModel() {
     private val events = MutableSharedFlow<Event>(extraBufferCapacity = 1)
 
@@ -45,7 +50,7 @@ class SettingsCategoryViewModel(
 
                 _state.update { it.copy(category = category) }
 
-                preferenceManager.allSettings(
+                preferenceRepository.allSettings(
                     category.settings.orEmpty().map { it.key },
                 )
                     .onEach { preferences ->
@@ -54,20 +59,52 @@ class SettingsCategoryViewModel(
             }
             .launchIn(viewModelScope)
 
+        // When auto-run is switch to enabled, check if we're ignoring battery optimization
+        preferenceRepository
+            .getValueByKey(SettingsKey.AUTOMATED_TESTING_ENABLED)
+            .runningFold(
+                initial = null as Pair<Any?, Any?>?,
+            ) { accumulator, value -> Pair(accumulator?.second, value) }
+            .filterNotNull()
+            .drop(1) // We only care about the first change of values
+            .onEach { (previousValue, currentValue) ->
+                if (previousValue != true && currentValue == true &&
+                    batteryOptimization.isSupported && !batteryOptimization.isIgnoring
+                ) {
+                    _state.update { it.copy(showIgnoreBatteryOptimizationNotice = true) }
+                }
+            }
+            .launchIn(viewModelScope)
+
         events.filterIsInstance<Event.SettingsCategoryClick>()
             .onEach { goToSettingsForCategory(it.category) }
             .launchIn(viewModelScope)
 
         events.filterIsInstance<Event.CheckedChangeClick>()
-            .onEach { preferenceManager.setValueByKey(it.key, it.value) }
+            .onEach { preferenceRepository.setValueByKey(it.key, it.value) }
             .launchIn(viewModelScope)
 
         events.filterIsInstance<Event.IntChanged>()
-            .onEach { preferenceManager.setValueByKey(it.key, it.value) }
+            .onEach { preferenceRepository.setValueByKey(it.key, it.value) }
             .launchIn(viewModelScope)
 
         events.filterIsInstance<Event.BackClicked>()
             .onEach { onBack() }
+            .launchIn(viewModelScope)
+
+        events
+            .filterIsInstance<Event.IgnoreBatteryOptimizationAccepted>()
+            .onEach {
+                _state.update { it.copy(showIgnoreBatteryOptimizationNotice = false) }
+                if (batteryOptimization.isSupported && !batteryOptimization.isIgnoring) {
+                    batteryOptimization.requestIgnore()
+                }
+            }
+            .launchIn(viewModelScope)
+
+        events
+            .filterIsInstance<Event.IgnoreBatteryOptimizationDismissed>()
+            .onEach { _state.update { it.copy(showIgnoreBatteryOptimizationNotice = false) } }
             .launchIn(viewModelScope)
     }
 
@@ -78,6 +115,7 @@ class SettingsCategoryViewModel(
     data class State(
         val category: SettingsCategoryItem? = null,
         val preferences: Map<SettingsKey, Any?> = emptyMap(),
+        val showIgnoreBatteryOptimizationNotice: Boolean = false,
     )
 
     sealed interface Event {
@@ -88,5 +126,9 @@ class SettingsCategoryViewModel(
         data class IntChanged(val key: SettingsKey, val value: Int?) : Event
 
         data object BackClicked : Event
+
+        data object IgnoreBatteryOptimizationAccepted : Event
+
+        data object IgnoreBatteryOptimizationDismissed : Event
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/shared/IgnoreBatteryOptimizationDialog.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/shared/IgnoreBatteryOptimizationDialog.kt
@@ -1,0 +1,32 @@
+package org.ooni.probe.ui.shared
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import ooniprobe.composeapp.generated.resources.Modal_Autorun_BatteryOptimization_Reminder
+import ooniprobe.composeapp.generated.resources.Modal_Cancel
+import ooniprobe.composeapp.generated.resources.Modal_OK
+import ooniprobe.composeapp.generated.resources.Res
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun IgnoreBatteryOptimizationDialog(
+    onAccepted: () -> Unit,
+    onDismissed: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismissed,
+        text = { Text(stringResource(Res.string.Modal_Autorun_BatteryOptimization_Reminder)) },
+        confirmButton = {
+            TextButton(onClick = onAccepted) {
+                Text(stringResource(Res.string.Modal_OK))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissed) {
+                Text(stringResource(Res.string.Modal_Cancel))
+            }
+        },
+    )
+}


### PR DESCRIPTION
Closes #565 

--

@agrabeli There's new copy to approve. We'll show this message if auto-run is enabled, but the user hasn't allowed us to run in the background. We show it on app start, or if the user enabled auto-run.

<img width="497" alt="Screenshot 2025-03-11 at 13 16 03" src="https://github.com/user-attachments/assets/57b10ba6-721f-42d9-bc26-2f68329edc3c" />
