### PR TITLE
Group ForegroundServiceRestriction on Sentry

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/ooni/probe/background/DescriptorUpdateWorker.kt
+++ b/composeApp/src/androidMain/kotlin/org/ooni/probe/background/DescriptorUpdateWorker.kt
@@ -58,9 +58,10 @@ class DescriptorUpdateWorker(
         try {
             setForeground(getForegroundInfo())
         } catch (e: IllegalStateException) {
+            e.message?.let(Logger::i)
             Logger.w(
                 "DescriptorUpdateWorker: cannot start due to foreground service restriction",
-                ForegroundServiceRestriction(e),
+                ForegroundServiceRestriction(),
             )
             return Result.failure()
         }
@@ -122,7 +123,7 @@ class DescriptorUpdateWorker(
             .build()
     }
 
-    class ForegroundServiceRestriction(reason: IllegalStateException) : Exception(reason)
+    class ForegroundServiceRestriction : Exception()
 
     class EarlyStop(reason: Int?) : EarlyStopWorkerException(reason)
 

--- a/composeApp/src/androidMain/kotlin/org/ooni/probe/background/RunWorker.kt
+++ b/composeApp/src/androidMain/kotlin/org/ooni/probe/background/RunWorker.kt
@@ -68,9 +68,10 @@ class RunWorker(
         try {
             setForeground(getForegroundInfo())
         } catch (e: IllegalStateException) {
+            e.message?.let(Logger::i)
             Logger.w(
                 "Run Worker: cannot start due to foreground service restriction",
-                ForegroundServiceRestriction(e),
+                ForegroundServiceRestriction(),
             )
             return Result.failure()
         }
@@ -249,7 +250,7 @@ class RunWorker(
         }
     }
 
-    class ForegroundServiceRestriction(reason: IllegalStateException) : Exception(reason)
+    class ForegroundServiceRestriction : Exception()
 
     class EarlyStop(reason: Int?) : EarlyStopWorkerException(reason)
 


### PR DESCRIPTION
Avoid the different instances of ForegroundServiceRestriction on Sentry, by removing the exception message from the exception (but it still gets logged).

<img width="664" alt="Screenshot 2025-03-17 at 15 38 40" src="https://github.com/user-attachments/assets/256ff9d2-ef22-475a-8a37-e34f16146601" />
