### PR TITLE
Update navigation compose: matches the latest stable compose 1.7.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ android-fragment = { module = "androidx.fragment:fragment-ktx", version = "1.8.6
 android-work = { module = "androidx.work:work-runtime-ktx", version = "2.10.0" }
 
 lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version = "2.8.4" }
-navigation = { module = "org.jetbrains.androidx.navigation:navigation-compose", version = "2.7.0-alpha07" }
+navigation = { module = "org.jetbrains.androidx.navigation:navigation-compose", version = "2.8.0-alpha11" }
 window-size = { module = "org.jetbrains.compose.material3:material3-window-size-class", version.ref = "compose-plugin" }
 
 # Preferences


### PR DESCRIPTION
Matches the version mentioned on the latest stable here: https://github.com/JetBrains/compose-multiplatform/blob/master/CHANGELOG.md#173-december-2024