### PR TITLE
ProxyScreen: add BackHandler

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/settings/proxy/ProxyScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/settings/proxy/ProxyScreen.kt
@@ -1,5 +1,6 @@
 package org.ooni.probe.ui.settings.proxy
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
@@ -182,5 +183,8 @@ fun ProxyScreen(
                 )
             }
         }
+    }
+    BackHandler(enabled = state.proxyType == ProxyType.CUSTOM){
+        onEvent(ProxyViewModel.Event.BackClicked)
     }
 }


### PR DESCRIPTION
In v5.0.3, `ProxyViewModel.Event.BackClicked` isn't fired when users press the back button, the only way to save the custom proxy is clicking the ArrowBack icon (?) .

Fix ooni/probe#2850

Note: I'm not familiar with Compose.