### PR TITLE
feat: add support for `ooni://` deeplinks on desktop

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -344,8 +344,7 @@ compose.desktop {
             packageName = "ooni-probe"
             packageVersion = android.defaultConfig.versionName
 
-            modules("java.sql")
-            modules("jdk.unsupported")
+            modules("java.sql", "jdk.unsupported")
 
             macOS {
                 minimumSystemVersion = "10.15.0"

--- a/composeApp/src/commonMain/resources/assets/.gitignore
+++ b/composeApp/src/commonMain/resources/assets/.gitignore
@@ -1,2 +1,0 @@
-
-descriptors.json

--- a/composeApp/src/commonMain/resources/assets/.gitignore
+++ b/composeApp/src/commonMain/resources/assets/.gitignore
@@ -1,0 +1,2 @@
+
+descriptors.json

--- a/composeApp/src/desktopMain/kotlin/org/ooni/probe/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/org/ooni/probe/Main.kt
@@ -1,6 +1,7 @@
 package org.ooni.probe
 
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -12,6 +13,7 @@ import io.github.vinceglb.autolaunch.AutoLaunch
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import ooniprobe.composeapp.generated.resources.Res
@@ -19,13 +21,20 @@ import ooniprobe.composeapp.generated.resources.app_name
 import ooniprobe.composeapp.generated.resources.tray_icon
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.ooni.probe.data.models.DeepLink
+import java.awt.Desktop
 
 fun main() {
     application {
         val autoLaunch = AutoLaunch(appPackageName = "org.openobservatory.ooniprobe")
 
         var isWindowVisible by remember { mutableStateOf(!autoLaunch.isStartedViaAutostart()) }
+        val deepLinkFlow = MutableSharedFlow<DeepLink?>(extraBufferCapacity = 1)
+        val deepLink by deepLinkFlow.collectAsState(null)
 
+        Desktop.getDesktop().setOpenURIHandler { event ->
+            deepLinkFlow.tryEmit(DeepLink.AddDescriptor(event.uri.path.split("/").last()))
+        }
         // start an hourly background task that calls startSingleRun
         LaunchedEffect(Unit) {
             while (true) {
@@ -48,8 +57,12 @@ fun main() {
         ) {
             App(
                 dependencies = dependencies,
-                deepLink = null,
-                onDeeplinkHandled = {},
+                deepLink = deepLink,
+                onDeeplinkHandled = {
+                    deepLink?.let {
+                        deepLinkFlow.tryEmit(null)
+                    }
+                },
             )
         }
 

--- a/conveyor.conf
+++ b/conveyor.conf
@@ -17,6 +17,8 @@ app {
   // updates = aggressive
 
   mac.info-plist.LSMinimumSystemVersion = "10.15.0"
+
+  url-schemes = [ ooni ]
 }
 
 conveyor.compatibility-level = 17


### PR DESCRIPTION
Related with https://github.com/ooni/probe-multiplatform/issues/616

This is for macOS only. Need to integrate [unique4j](https://github.com/prat-man/unique4j) for [ complete implementation](https://conveyor.hydraulic.dev/17.0/configs/os-integration/#url-handlers-deep-linking)

NOTE: The app has to be installed to be tested.


use `open ooni://runv2/10004` from terminal or open link in the browser