### PR TITLE
Fix stop button after multiple Run Worker were started

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
@@ -431,7 +431,6 @@ class Dependencies(
             getAutoRunSpecification = getAutoRunSpecification::invoke,
             runDescriptors = runDescriptors::invoke,
             addRunCancelListener = runBackgroundStateManager::addCancelListener,
-            clearRunCancelListeners = runBackgroundStateManager::clearCancelListeners,
             setRunBackgroundState = runBackgroundStateManager::updateState,
             getRunBackgroundState = runBackgroundStateManager::observeState,
             getLatestResult = resultRepository::getLatest,

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunBackgroundStateManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunBackgroundStateManager.kt
@@ -42,16 +42,17 @@ class RunBackgroundStateManager(
 
     // Cancels
 
-    fun addCancelListener(listener: () -> Unit) {
+    fun addCancelListener(listener: () -> Unit): CancelListenerCallback {
         cancelListeners.add(listener)
-    }
-
-    fun clearCancelListeners() {
-        cancelListeners.clear()
+        return CancelListenerCallback { cancelListeners.remove(listener) }
     }
 
     fun cancel() {
         cancelListeners.forEach { it() }
-        clearCancelListeners()
+        cancelListeners.clear()
     }
+}
+
+fun interface CancelListenerCallback {
+    fun dismiss()
 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunDescriptors.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunDescriptors.kt
@@ -28,7 +28,7 @@ class RunDescriptors(
     private val getRunBackgroundState: Flow<RunBackgroundState>,
     private val setRunBackgroundState: ((RunBackgroundState) -> RunBackgroundState) -> Unit,
     private val runNetTest: suspend (RunNetTest.Specification) -> Unit,
-    private val addRunCancelListener: (() -> Unit) -> Unit,
+    private val addRunCancelListener: (() -> Unit) -> CancelListenerCallback,
     private val reportTestRunError: (TestRunError) -> Unit,
     private val getEnginePreferences: suspend () -> EnginePreferences,
     private val finishInProgressData: suspend () -> Unit,
@@ -67,7 +67,7 @@ class RunDescriptors(
         descriptors: List<Descriptor>,
         spec: RunSpecification.Full,
     ) {
-        addRunCancelListener {
+        val cancelListenerCallback = addRunCancelListener {
             setRunBackgroundState { RunBackgroundState.Stopping }
         }
 
@@ -76,6 +76,8 @@ class RunDescriptors(
             if (isRunStopped()) return@forEachIndexed
             runDescriptor(descriptor, index, spec.taskOrigin, spec.isRerun)
         }
+
+        cancelListenerCallback.dismiss()
     }
 
     private suspend fun List<Descriptor>.prepareInputs(taskOrigin: TaskOrigin) =

--- a/composeApp/src/commonTest/kotlin/org/ooni/engine/EngineTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/engine/EngineTest.kt
@@ -14,6 +14,7 @@ import org.ooni.engine.models.TestType
 import org.ooni.probe.data.models.BatteryState
 import org.ooni.probe.data.models.NetTest
 import org.ooni.probe.di.Dependencies
+import org.ooni.probe.domain.CancelListenerCallback
 import org.ooni.probe.shared.Platform
 import org.ooni.probe.shared.PlatformInfo
 import kotlin.test.Test
@@ -91,7 +92,7 @@ class EngineTest {
                     maxRuntime = null,
                 )
             },
-            addRunCancelListener = {},
+            addRunCancelListener = { CancelListenerCallback {} },
             backgroundContext = Dispatchers.Unconfined,
         )
 }

--- a/composeApp/src/commonTest/kotlin/org/ooni/probe/background/RunBackgroundTaskTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/probe/background/RunBackgroundTaskTest.kt
@@ -12,6 +12,7 @@ import org.ooni.probe.data.models.ResultModel
 import org.ooni.probe.data.models.RunBackgroundState
 import org.ooni.probe.data.models.RunSpecification
 import org.ooni.probe.data.models.SettingsKey
+import org.ooni.probe.domain.CancelListenerCallback
 import org.ooni.probe.domain.UploadMissingMeasurements
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -51,8 +52,7 @@ class RunBackgroundTaskTest {
         runDescriptors: suspend (RunSpecification) -> Unit = {},
         setRunBackgroundState: ((RunBackgroundState) -> RunBackgroundState) -> Unit = {},
         getRunBackgroundState: () -> Flow<RunBackgroundState> = { flowOf(RunBackgroundState.Idle()) },
-        addRunCancelListener: (() -> Unit) -> Unit = {},
-        clearRunCancelListeners: () -> Unit = {},
+        addRunCancelListener: (() -> Unit) -> CancelListenerCallback = { CancelListenerCallback {} },
         getLatestResult: () -> Flow<ResultModel?> = { flowOf(null) },
     ) = RunBackgroundTask(
         getPreferenceValueByKey = getPreferenceValueByKey,
@@ -63,7 +63,6 @@ class RunBackgroundTaskTest {
         setRunBackgroundState = setRunBackgroundState,
         getRunBackgroundState = getRunBackgroundState,
         addRunCancelListener = addRunCancelListener,
-        clearRunCancelListeners = clearRunCancelListeners,
         getLatestResult = getLatestResult,
     )
 }


### PR DESCRIPTION
@hellais I was able to reproduce something similar to what you had as well with https://github.com/ooni/probe-multiplatform/issues/646 But it only happened if I started a manual run, and then an auto-run wanted to start but couldn't. (Not very common to happen, I was testing out edge cases.)

@aanorbel Now instead of clearing all cancel listeners all together at the end, each listener is responsible for clearing itself when it's no longer needed.