### PR TITLE
feat: only auto-update descriptors if installed

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/App.kt
@@ -98,8 +98,10 @@ fun App(
     LaunchedEffect(Unit) {
         dependencies.bootstrapTestDescriptors()
         dependencies.bootstrapPreferences()
-        dependencies.configureDescriptorAutoUpdate()
-        dependencies.startDescriptorsUpdate(null)
+        if (dependencies.hasTestDescriptorInstalled()) {
+            dependencies.configureDescriptorAutoUpdate()
+            dependencies.startDescriptorsUpdate(null)
+        }
         dependencies.startSingleRunInner(RunSpecification.OnlyUploadMissingResults)
     }
     LaunchedEffect(Unit) {

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.Preferences
 import app.cash.sqldelight.db.SqlDriver
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.first
 import kotlinx.serialization.json.Json
 import okio.FileSystem
 import okio.Path.Companion.toPath
@@ -648,6 +649,8 @@ class Dependencies(
             getPreferencesByKeys = preferenceRepository::allSettings,
             setPreferenceValuesByKeys = preferenceRepository::setValuesByKey,
         )
+
+    suspend fun hasTestDescriptorInstalled() = testDescriptorRepository.listAll().first().isNotEmpty()
 
     companion object {
         @VisibleForTesting


### PR DESCRIPTION
Closes https://github.com/ooni/probe-multiplatform/issues/653
The application now checks if test descriptors are installed before attempting to auto-update them.