### PR TITLE
Show no internet error message at run start

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings-common.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings-common.xml
@@ -317,6 +317,7 @@
     <string name="Modal_RunAnyway">Run anyways</string>
     <string name="Modal_AlwaysRun">Always Run</string>
     <string name="Modal_Error_CantDownloadURLs">Unable to download URL list. Please try again.</string>
+    <string name="Modal_Error_NoInternet">No Internet connection</string>
     <string name="Modal_CustomURL_Title_NotSaved">Are you sure?</string>
     <string name="Modal_CustomURL_NotSaved">Your URLs will not be saved when you leave this screen. Are you sure you want to leave this screen?</string>
     <string name="Modal_Autorun_BatteryOptimization_Onboarding">The application cannot run tests automatically without background permission. Do you want to try again?</string>

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/data/models/TestRunError.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/data/models/TestRunError.kt
@@ -2,4 +2,6 @@ package org.ooni.probe.data.models
 
 sealed interface TestRunError {
     data object DownloadUrlsFailed : TestRunError
+
+    data object NoInternet : TestRunError
 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
@@ -381,6 +381,7 @@ class Dependencies(
             reportTestRunError = runBackgroundStateManager::reportError,
             getEnginePreferences = getEnginePreferences::invoke,
             finishInProgressData = finishInProgressData::invoke,
+            networkTypeFinder = networkTypeFinder::invoke,
         )
     }
     private val saveTestDescriptors by lazy {

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunDescriptors.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunDescriptors.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.datetime.LocalDateTime
 import org.ooni.engine.Engine.MkException
 import org.ooni.engine.models.EnginePreferences
+import org.ooni.engine.models.NetworkType
 import org.ooni.engine.models.Result
 import org.ooni.engine.models.TaskOrigin
 import org.ooni.engine.models.TestType
@@ -32,6 +33,7 @@ class RunDescriptors(
     private val reportTestRunError: (TestRunError) -> Unit,
     private val getEnginePreferences: suspend () -> EnginePreferences,
     private val finishInProgressData: suspend () -> Unit,
+    private val networkTypeFinder: () -> NetworkType,
 ) {
     suspend operator fun invoke(spec: RunSpecification.Full) {
         Instrumentation.withTransaction(
@@ -50,6 +52,10 @@ class RunDescriptors(
 
             setRunBackgroundState {
                 RunBackgroundState.RunningTests(estimatedRuntimeOfDescriptors = estimatedRuntime)
+            }
+
+            if (networkTypeFinder() == NetworkType.NoInternet) {
+                reportTestRunError(TestRunError.NoInternet)
             }
 
             try {

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/shared/TestRunErrorMessages.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/shared/TestRunErrorMessages.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import kotlinx.coroutines.delay
 import ooniprobe.composeapp.generated.resources.Modal_Error_CantDownloadURLs
+import ooniprobe.composeapp.generated.resources.Modal_Error_NoInternet
 import ooniprobe.composeapp.generated.resources.Res
 import org.jetbrains.compose.resources.getString
 import org.ooni.probe.LocalSnackbarHostState
@@ -22,6 +23,7 @@ fun TestRunErrorMessages(
             getString(
                 when (error) {
                     TestRunError.DownloadUrlsFailed -> Res.string.Modal_Error_CantDownloadURLs
+                    TestRunError.NoInternet -> Res.string.Modal_Error_NoInternet
                 },
             ),
         )


### PR DESCRIPTION
Closes #632 

@hellais @agrabeli New small copy to validate: "No Internet connection"

Video for context:

https://github.com/user-attachments/assets/6899bfdb-bb48-4c94-9cc9-2d2f3f432f86

