### PR TITLE
Desktop tray string resources

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/ooni/probe/background/RunWorker.kt
+++ b/composeApp/src/androidMain/kotlin/org/ooni/probe/background/RunWorker.kt
@@ -175,7 +175,7 @@ class RunWorker(
                 setContentText(
                     getString(
                         Res.string.Results_UploadingMissing,
-                        "$progress/${state.total}",
+                        state.progressText,
                     ),
                 )
                     .setProgress(state.total, progress, false)

--- a/composeApp/src/commonMain/composeResources/values/strings-common.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings-common.xml
@@ -328,6 +328,10 @@
     <string name="Modal_Autorun_BatteryOptimization_Onboarding">The application cannot run tests automatically without background permission. Do you want to try again?</string>
     <string name="Modal_Autorun_BatteryOptimization_Reminder">The application needs permission to run tests automatically in the background.</string>
 
+    <!-- Desktop -->
+    <string name="Desktop_OpenApp">Open App</string>
+    <string name="Desktop_Quit">Quit</string>
+
     <!-- Common / Others -->
 
     <string name="OONIRun_Run">Run</string>

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/UploadMissingMeasurements.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/UploadMissingMeasurements.kt
@@ -97,7 +97,10 @@ class UploadMissingMeasurements(
             val uploaded: Int,
             val failedToUpload: Int,
             val total: Int,
-        ) : State
+        ) : State {
+            val progressText
+                get() = "${uploaded + failedToUpload + 1}/$total"
+        }
 
         data class Finished(
             val uploaded: Int,

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/dashboard/RunBackgroundStateSection.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/dashboard/RunBackgroundStateSection.kt
@@ -114,11 +114,10 @@ private fun UploadingMissingResults(state: RunBackgroundState.UploadingMissingRe
 
         when (val uploadState = state.state) {
             is UploadMissingMeasurements.State.Uploading -> {
-                val progress = uploadState.uploaded + uploadState.failedToUpload + 1
                 Text(
                     text = stringResource(
                         Res.string.Results_UploadingMissing,
-                        "$progress/${uploadState.total}",
+                        uploadState.progressText,
                     ),
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.Bold,


### PR DESCRIPTION
Closes #700 

@hellais and @agrabeli two small strings to review:

<img width="153" alt="Screenshot 2025-05-05 at 15 34 42" src="https://github.com/user-attachments/assets/c801f3f7-160a-4033-8215-9acdf3bcb670" />
