### PR TITLE
Mark all results as viewed

### DIFF
--- a/composeApp/src/commonMain/composeResources/drawable/ic_mark_as_viewed.xml
+++ b/composeApp/src/commonMain/composeResources/drawable/ic_mark_as_viewed.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M268,720L42,494L99,438L269,608L269,608L325,664L268,720ZM494,720L268,494L324,437L494,607L862,239L918,296L494,720ZM494,494L437,438L635,240L692,296L494,494Z"/>
+</vector>

--- a/composeApp/src/commonMain/composeResources/values/strings-common.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings-common.xml
@@ -110,6 +110,8 @@
     <string name="Results_TaskOrigin_All">All Sources</string>
     <string name="Results_LimitedNotice">Only the last %1$d results are shown</string>
     <string name="Results_UploadingMissing">Uploading missing results %1$s</string>
+    <string name="Results_MarkAllAsViewed">Mark all as viewed</string>
+    <string name="Results_MarkAllAsViewed_Confirmation">Do you want to mark all results as viewed?</string>
 
     <!-- Measurements -->
 
@@ -346,6 +348,7 @@
     <string name="Common_Collapse">Collapse</string>
     <string name="Common_Expand">Expand</string>
     <string name="Common_Enable">Enable</string>
+    <string name="Common_Yes">Yes</string>
     <string name="Common_Ago">%1$s ago</string>
     <string name="Common_Minutes_One">%1$d minute</string>
     <string name="Common_Minutes_Other">%1$d minutes</string>

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/data/repositories/ResultRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/data/repositories/ResultRepository.kt
@@ -109,6 +109,11 @@ class ResultRepository(
             database.resultQueries.markAsViewed(resultId.value)
         }
 
+    suspend fun markAllAsViewed() =
+        withContext(backgroundContext) {
+            database.resultQueries.markAllAsViewed()
+        }
+
     suspend fun markAsDone(resultId: ResultModel.Id) =
         withContext(backgroundContext) {
             database.resultQueries.markAsDone(resultId.value)

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
@@ -570,6 +570,7 @@ class Dependencies(
         getDescriptors = getTestDescriptors::latest,
         deleteAllResults = deleteAllResults::invoke,
         markJustFinishedTestAsSeen = markJustFinishedTestAsSeen::invoke,
+        markAllAsViewed = resultRepository::markAllAsViewed,
     )
 
     fun runningViewModel(

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/results/ResultsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/results/ResultsScreen.kt
@@ -42,11 +42,14 @@ import kotlinx.datetime.LocalDate.Companion.Format
 import kotlinx.datetime.format
 import kotlinx.datetime.format.MonthNames
 import kotlinx.datetime.format.char
+import ooniprobe.composeapp.generated.resources.Common_Yes
 import ooniprobe.composeapp.generated.resources.Modal_Cancel
 import ooniprobe.composeapp.generated.resources.Modal_Delete
 import ooniprobe.composeapp.generated.resources.Modal_DoYouWantToDeleteAllTests
 import ooniprobe.composeapp.generated.resources.Res
 import ooniprobe.composeapp.generated.resources.Results_LimitedNotice
+import ooniprobe.composeapp.generated.resources.Results_MarkAllAsViewed
+import ooniprobe.composeapp.generated.resources.Results_MarkAllAsViewed_Confirmation
 import ooniprobe.composeapp.generated.resources.Snackbar_ResultsSomeNotUploaded_Text
 import ooniprobe.composeapp.generated.resources.Snackbar_ResultsSomeNotUploaded_UploadAll
 import ooniprobe.composeapp.generated.resources.TestResults_Overview_FilterTests
@@ -59,6 +62,7 @@ import ooniprobe.composeapp.generated.resources.TestResults_Summary_Performance_
 import ooniprobe.composeapp.generated.resources.TestResults_Summary_Performance_Hero_Upload
 import ooniprobe.composeapp.generated.resources.ic_delete_all
 import ooniprobe.composeapp.generated.resources.ic_download
+import ooniprobe.composeapp.generated.resources.ic_mark_as_viewed
 import ooniprobe.composeapp.generated.resources.ic_upload
 import ooniprobe.composeapp.generated.resources.ooni_empty_state
 import org.jetbrains.compose.resources.painterResource
@@ -74,6 +78,7 @@ fun ResultsScreen(
     onEvent: (ResultsViewModel.Event) -> Unit,
 ) {
     var showDeleteConfirm by remember { mutableStateOf(false) }
+    var showMarkAsViewedConfirm by remember { mutableStateOf(false) }
 
     Column(Modifier.background(MaterialTheme.colorScheme.background)) {
         TopBar(
@@ -81,6 +86,17 @@ fun ResultsScreen(
                 Text(stringResource(Res.string.TestResults_Overview_Title))
             },
             actions = {
+                if (!state.isLoading && state.results.any() && state.filter.isAll) {
+                    IconButton(
+                        onClick = { showMarkAsViewedConfirm = true },
+                        enabled = state.markAllAsViewedEnabled,
+                    ) {
+                        Icon(
+                            painterResource(Res.drawable.ic_mark_as_viewed),
+                            contentDescription = stringResource(Res.string.Results_MarkAllAsViewed),
+                        )
+                    }
+                }
                 if (!state.isLoading && state.results.any() && state.filter.isAll) {
                     IconButton(onClick = { showDeleteConfirm = true }) {
                         Icon(
@@ -172,6 +188,18 @@ fun ResultsScreen(
             },
             onDismiss = {
                 showDeleteConfirm = false
+            },
+        )
+    }
+
+    if (showMarkAsViewedConfirm) {
+        MarkAllAsViewedConfirmDialog(
+            onConfirm = {
+                onEvent(ResultsViewModel.Event.MarkAllAsViewedClick)
+                showMarkAsViewedConfirm = false
+            },
+            onDismiss = {
+                showMarkAsViewedConfirm = false
             },
         )
     }
@@ -352,6 +380,29 @@ private fun DeleteConfirmDialog(
                     stringResource(Res.string.Modal_Delete),
                     color = MaterialTheme.colorScheme.error,
                 )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = { onDismiss() }) {
+                Text(stringResource(Res.string.Modal_Cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun MarkAllAsViewedConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = { onDismiss() },
+        text = {
+            Text(stringResource(Res.string.Results_MarkAllAsViewed_Confirmation))
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm() }) {
+                Text(stringResource(Res.string.Common_Yes))
             }
         },
         dismissButton = {

--- a/composeApp/src/commonMain/sqldelight/org/ooni/probe/data/Result.sq
+++ b/composeApp/src/commonMain/sqldelight/org/ooni/probe/data/Result.sq
@@ -38,6 +38,9 @@ INSERT OR REPLACE INTO Result (
 markAsViewed:
 UPDATE Result SET is_viewed = 1 WHERE id = ?;
 
+markAllAsViewed:
+UPDATE Result SET is_viewed = 1;
+
 markAsDone:
 UPDATE Result SET is_done = 1 WHERE id = ?;
 

--- a/composeApp/src/commonTest/kotlin/org/ooni/probe/data/repositories/ResultRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/probe/data/repositories/ResultRepositoryTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class ResultRepositoryTest {
     private lateinit var subject: ResultRepository
@@ -100,5 +101,26 @@ class ResultRepositoryTest {
                 ),
             )
             assertEquals(0, subject.countMissingUpload().first())
+        }
+
+    @Test
+    fun markAsViewed() =
+        runTest {
+            val model = ResultModelFactory.build(isViewed = false)
+            subject.createOrUpdate(model)
+
+            subject.markAsViewed(model.id!!)
+
+            assertTrue(subject.getById(model.id!!).first()!!.first.isViewed)
+        }
+
+    @Test
+    fun markAllAsViewed() =
+        runTest {
+            subject.createOrUpdate(ResultModelFactory.build(isViewed = false))
+
+            subject.markAllAsViewed()
+
+            assertTrue(subject.getLatest().first()!!.isViewed)
         }
 }


### PR DESCRIPTION
Toolbar button to mark all results as viewed.

@hellais and @agrabeli there's more copy to review:

`Do you want to mark all results as viewed?`

<img src="https://github.com/user-attachments/assets/f16adc59-aa94-4f62-9e3a-1c58eeae221c" width=300/>
