### PR TITLE
Increase log size

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/shared/monitoring/AppLogger.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/shared/monitoring/AppLogger.kt
@@ -91,6 +91,6 @@ class AppLogger(
 
     companion object {
         val FILE_PATH = "Log/logger.txt".toPath()
-        private const val MAX_LINES = 1000
+        private const val MAX_LINES = 10_000
     }
 }


### PR DESCRIPTION
I feel 1000 lines is too little if the users have debug logs enabled.