### PR TITLE
fix: ensure desktop request foreground is supported before calling

### DIFF
--- a/composeApp/src/desktopMain/kotlin/org/ooni/probe/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/org/ooni/probe/Main.kt
@@ -77,7 +77,13 @@ fun main(args: Array<String>) {
 
         fun showWindow() {
             isWindowVisible = true
-            Desktop.getDesktop().requestForeground(true)
+            if (Desktop.isDesktopSupported() &&
+                Desktop
+                    .getDesktop()
+                    .isSupported(Desktop.Action.APP_REQUEST_FOREGROUND)
+            ) {
+                Desktop.getDesktop().requestForeground(true)
+            }
         }
 
         Window(


### PR DESCRIPTION
Closes https://github.com/ooni/probe-multiplatform/issues/876