### PR TITLE
Delete old results

### DIFF
--- a/composeApp/src/androidInstrumentedTest/kotlin/org/ooni/probe/uitesting/SettingsTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/org/ooni/probe/uitesting/SettingsTest.kt
@@ -2,12 +2,15 @@ package org.ooni.probe.uitesting
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import ooniprobe.composeapp.generated.resources.CategoryCode_ANON_Name
 import ooniprobe.composeapp.generated.resources.Common_Back
+import ooniprobe.composeapp.generated.resources.Modal_OK
 import ooniprobe.composeapp.generated.resources.Res
 import ooniprobe.composeapp.generated.resources.Settings_Advanced_DebugLogs
 import ooniprobe.composeapp.generated.resources.Settings_Advanced_Label
@@ -18,6 +21,8 @@ import ooniprobe.composeapp.generated.resources.Settings_Privacy_Label
 import ooniprobe.composeapp.generated.resources.Settings_Privacy_SendCrashReports
 import ooniprobe.composeapp.generated.resources.Settings_Proxy_Label
 import ooniprobe.composeapp.generated.resources.Settings_Proxy_Psiphon
+import ooniprobe.composeapp.generated.resources.Settings_Results_DeleteOldResults
+import ooniprobe.composeapp.generated.resources.Settings_Results_DeleteOldResultsThreshold
 import ooniprobe.composeapp.generated.resources.Settings_Sharing_UploadResults
 import ooniprobe.composeapp.generated.resources.Settings_TestOptions_Label
 import ooniprobe.composeapp.generated.resources.Settings_Title
@@ -30,7 +35,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.ooni.engine.models.WebConnectivityCategory
-import org.ooni.probe.data.models.ProxyProtocol
+import org.ooni.probe.data.models.ProxyOption
 import org.ooni.probe.data.models.SettingsKey
 import org.ooni.probe.uitesting.helpers.clickOnContentDescription
 import org.ooni.probe.uitesting.helpers.clickOnText
@@ -149,9 +154,7 @@ class SettingsTest {
     fun proxy() =
         runTest {
             preferences.setValuesByKey(
-                listOf(
-                    SettingsKey.PROXY_PROTOCOL to "NONE",
-                ),
+                listOf(SettingsKey.PROXY_SELECTED to ProxyOption.None.value),
             )
 
             with(compose) {
@@ -161,8 +164,8 @@ class SettingsTest {
 
                 wait {
                     preferences
-                        .getValueByKey(SettingsKey.PROXY_PROTOCOL)
-                        .first() == ProxyProtocol.PSIPHON.value
+                        .getValueByKey(SettingsKey.PROXY_SELECTED)
+                        .first() == ProxyOption.Psiphon.value
                 }
             }
         }
@@ -186,6 +189,14 @@ class SettingsTest {
 
                 clickOnText(Res.string.Settings_WarmVPNInUse_Label)
                 wait { preferences.getValueByKey(SettingsKey.WARN_VPN_IN_USE).first() == true }
+
+                clickOnText(Res.string.Settings_Results_DeleteOldResults)
+                wait { preferences.getValueByKey(SettingsKey.DELETE_OLD_RESULTS).first() == true }
+
+                clickOnText(Res.string.Settings_Results_DeleteOldResultsThreshold)
+                onNodeWithTag("NumberPickerField").performTextInput("8")
+                clickOnText(Res.string.Modal_OK)
+                wait { preferences.getValueByKey(SettingsKey.DELETE_OLD_RESULTS_THRESHOLD).first() == 8 }
             }
         }
 }

--- a/composeApp/src/commonMain/composeResources/values/strings-common.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings-common.xml
@@ -220,6 +220,14 @@
     <string name="Settings_Advanced_DebugLogs">Debug logs</string>
     <string name="Settings_Advanced_RecentLogs">See recent logs</string>
 
+    <string name="Settings_Results_DeleteOldResults">Delete old results</string>
+    <string name="Settings_Results_DeleteOldResultsThreshold">Delete results older than</string>
+    <plurals name="Settings_Results_DeleteOldResultsThreshold_Description">
+        <item quantity="one">%1$d month</item>
+        <item quantity="other">%1$d months</item>
+    </plurals>
+    <string name="Settings_Results_DeleteOldResultsThreshold_Unit">Enter the number of months</string>
+
     <string name="Settings_Support_Label">Support</string>
     <string name="Settings_Support_SendEmail">Send email to support</string>
     <string name="Settings_Support_Message">Please describe the problem you are experiencing:</string>

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/App.kt
@@ -123,6 +123,7 @@ fun App(
     }
     LaunchedEffect(Unit) {
         dependencies.finishInProgressData()
+        dependencies.deleteOldResults()
     }
     LaunchedEffect(Unit) {
         dependencies.observeAndConfigureAutoRun()

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/data/models/SettingsKey.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/data/models/SettingsKey.kt
@@ -9,6 +9,8 @@ enum class SettingsKey(
     AUTOMATED_TESTING_CHARGING("automated_testing_charging"),
     MAX_RUNTIME_ENABLED("max_runtime_enabled"),
     MAX_RUNTIME("max_runtime"),
+    DELETE_OLD_RESULTS("delete_old_results"),
+    DELETE_OLD_RESULTS_THRESHOLD("delete_old_results_threshold"),
 
     // Website categories
     SRCH("SRCH"),

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/data/repositories/PreferenceRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/data/repositories/PreferenceRepository.kt
@@ -77,6 +77,7 @@ class PreferenceRepository(
         return when (key) {
             SettingsKey.MAX_RUNTIME,
             SettingsKey.LEGACY_PROXY_PORT,
+            SettingsKey.DELETE_OLD_RESULTS_THRESHOLD,
             -> PreferenceKey.IntKey(intPreferencesKey(preferenceKey))
 
             SettingsKey.LEGACY_PROXY_HOSTNAME,
@@ -210,8 +211,7 @@ class PreferenceRepository(
         prefix = (descriptor.source as? Descriptor.Source.Installed)
             ?.value
             ?.id
-            ?.value
-            ?.toString(),
+            ?.value,
         autoRun = isAutoRun,
     )
 

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
@@ -48,6 +48,7 @@ import org.ooni.probe.domain.BootstrapPreferences
 import org.ooni.probe.domain.CheckAutoRunConstraints
 import org.ooni.probe.domain.ClearStorage
 import org.ooni.probe.domain.DeleteMeasurementsWithoutResult
+import org.ooni.probe.domain.DeleteOldResults
 import org.ooni.probe.domain.DeleteResults
 import org.ooni.probe.domain.DownloadUrls
 import org.ooni.probe.domain.FinishInProgressData
@@ -258,6 +259,12 @@ class Dependencies(
             getMeasurementsWithoutResult = measurementRepository::listWithoutResult,
             deleteMeasurementsById = measurementRepository::deleteByIds,
             deleteFile = deleteFiles::invoke,
+        )
+    }
+    val deleteOldResults by lazy {
+        DeleteOldResults(
+            getPreferenceByKey = preferenceRepository::getValueByKey,
+            deleteResultsByFilter = deleteResults::byFilter,
         )
     }
     private val deleteResults by lazy {

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/BootstrapPreferences.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/BootstrapPreferences.kt
@@ -30,6 +30,9 @@ class BootstrapPreferences(
                 SettingsKey.AUTOMATED_TESTING_WIFIONLY to true,
                 SettingsKey.AUTOMATED_TESTING_CHARGING to true,
                 SettingsKey.WARN_VPN_IN_USE to true,
+                SettingsKey.DELETE_OLD_RESULTS to true,
+                SettingsKey.DELETE_OLD_RESULTS_THRESHOLD to
+                    DeleteOldResults.DELETE_OLD_RESULTS_THRESHOLD_DEFAULT_IN_MONTHS,
             ) +
                 organizationPreferenceDefaults(),
         )

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/DeleteOldResults.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/DeleteOldResults.kt
@@ -1,0 +1,40 @@
+package org.ooni.probe.domain
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
+import org.ooni.probe.data.models.ResultFilter
+import org.ooni.probe.data.models.SettingsKey
+import org.ooni.probe.shared.today
+
+class DeleteOldResults(
+    val getPreferenceByKey: (SettingsKey) -> Flow<Any?>,
+    val deleteResultsByFilter: suspend (ResultFilter) -> Unit,
+) {
+    suspend operator fun invoke() {
+        if (getPreferenceByKey(SettingsKey.DELETE_OLD_RESULTS).first() != true) return
+
+        val keepThresholdInMonths =
+            (getPreferenceByKey(SettingsKey.DELETE_OLD_RESULTS_THRESHOLD).first() as? Int)
+                ?.coerceAtLeast(1)
+                ?: DELETE_OLD_RESULTS_THRESHOLD_DEFAULT_IN_MONTHS
+        val startDate = LocalDate.fromEpochDays(0)
+        val endDate = LocalDate
+            .today()
+            .minus(keepThresholdInMonths, DateTimeUnit.MONTH)
+            .coerceAtLeast(startDate)
+        deleteResultsByFilter(
+            ResultFilter(
+                dates = ResultFilter.Date.Custom(
+                    customRange = startDate..endDate,
+                ),
+            ),
+        )
+    }
+
+    companion object {
+        const val DELETE_OLD_RESULTS_THRESHOLD_DEFAULT_IN_MONTHS = 6
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/GetSettings.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/GetSettings.kt
@@ -34,6 +34,10 @@ import ooniprobe.composeapp.generated.resources.Settings_Legacy_Storage
 import ooniprobe.composeapp.generated.resources.Settings_Privacy_Label
 import ooniprobe.composeapp.generated.resources.Settings_Privacy_SendCrashReports
 import ooniprobe.composeapp.generated.resources.Settings_Proxy_Label
+import ooniprobe.composeapp.generated.resources.Settings_Results_DeleteOldResults
+import ooniprobe.composeapp.generated.resources.Settings_Results_DeleteOldResultsThreshold
+import ooniprobe.composeapp.generated.resources.Settings_Results_DeleteOldResultsThreshold_Description
+import ooniprobe.composeapp.generated.resources.Settings_Results_DeleteOldResultsThreshold_Unit
 import ooniprobe.composeapp.generated.resources.Settings_Sharing_UploadResults
 import ooniprobe.composeapp.generated.resources.Settings_Sharing_UploadResults_Description
 import ooniprobe.composeapp.generated.resources.Settings_Storage_Clear
@@ -54,6 +58,7 @@ import ooniprobe.composeapp.generated.resources.ic_support
 import ooniprobe.composeapp.generated.resources.outline_info
 import ooniprobe.composeapp.generated.resources.privacy
 import ooniprobe.composeapp.generated.resources.proxy
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import org.ooni.engine.models.WebConnectivityCategory
 import org.ooni.probe.config.OrganizationConfig
@@ -66,8 +71,8 @@ import org.ooni.probe.data.models.SettingsKey
 import org.ooni.probe.data.repositories.PreferenceRepository
 import org.ooni.probe.ui.settings.category.SettingsDescription
 import org.ooni.probe.ui.settings.donate.DONATE_SETTINGS_ITEM
-import org.ooni.probe.ui.shared.formatDataUsage
 import org.ooni.probe.ui.shared.format
+import org.ooni.probe.ui.shared.formatDataUsage
 import kotlin.time.Duration.Companion.seconds
 
 class GetSettings(
@@ -89,6 +94,8 @@ class GetSettings(
                     SettingsKey.AUTOMATED_TESTING_ENABLED,
                     SettingsKey.MAX_RUNTIME_ENABLED,
                     SettingsKey.MAX_RUNTIME,
+                    SettingsKey.DELETE_OLD_RESULTS,
+                    SettingsKey.DELETE_OLD_RESULTS_THRESHOLD,
                 ),
             ),
             observeStorageUsed(),
@@ -101,6 +108,8 @@ class GetSettings(
                 enabledCategoriesCount = enabledCategoriesCount,
                 maxRuntimeEnabled = preferences[SettingsKey.MAX_RUNTIME_ENABLED] == true,
                 maxRuntime = preferences[SettingsKey.MAX_RUNTIME] as? Int,
+                deleteOldResults = preferences[SettingsKey.DELETE_OLD_RESULTS] == true,
+                deleteOldResultsThreshold = preferences[SettingsKey.DELETE_OLD_RESULTS_THRESHOLD] as? Int,
                 storageUsed = storageUsed,
                 supportsCrashReporting = supportsCrashReporting,
             )
@@ -112,6 +121,8 @@ class GetSettings(
         enabledCategoriesCount: Int,
         maxRuntimeEnabled: Boolean,
         maxRuntime: Int?,
+        deleteOldResults: Boolean,
+        deleteOldResultsThreshold: Int?,
         storageUsed: Long,
         supportsCrashReporting: Boolean = false,
     ): List<SettingsCategoryItem> =
@@ -176,7 +187,6 @@ class GetSettings(
                                     style = MaterialTheme.typography.labelLarge,
                                 )
                             },
-                            indentation = 0,
                         )
                     } else {
                         null
@@ -295,6 +305,37 @@ class GetSettings(
                         key = SettingsKey.WARN_VPN_IN_USE,
                         type = PreferenceItemType.SWITCH,
                     ),
+                    SettingsItem(
+                        title = Res.string.Settings_Results_DeleteOldResults,
+                        key = SettingsKey.DELETE_OLD_RESULTS,
+                        type = PreferenceItemType.SWITCH,
+                    ),
+                    if (deleteOldResults) {
+                        SettingsItem(
+                            title = Res.string.Settings_Results_DeleteOldResultsThreshold,
+                            key = SettingsKey.DELETE_OLD_RESULTS_THRESHOLD,
+                            type = PreferenceItemType.INT,
+                            supportingContent = {
+                                val value = (
+                                    deleteOldResultsThreshold
+                                        ?: DeleteOldResults.DELETE_OLD_RESULTS_THRESHOLD_DEFAULT_IN_MONTHS
+                                ).coerceAtLeast(1)
+                                Text(
+                                    pluralStringResource(
+                                        Res.plurals.Settings_Results_DeleteOldResultsThreshold_Description,
+                                        value,
+                                        value,
+                                    ),
+                                )
+                            },
+                            valuePickerSupportContent = {
+                                Text(stringResource(Res.string.Settings_Results_DeleteOldResultsThreshold_Unit))
+                            },
+                            indentation = 1,
+                        )
+                    } else {
+                        null
+                    },
                     if (isCleanUpRequired() && cleanupLegacyDirectories != null) {
                         SettingsItem(
                             title = Res.string.Settings_Legacy_Storage,


### PR DESCRIPTION
Closes https://github.com/ooni/probe/issues/1983

This feature is disabled for existing users by default, so it doesn't automatically delete their old results without their knowledge.

@hellais / @agrabeli There's a little bit of copy to review here. See screenshots:

|.|.|
|-|-|
|<img width="1080" height="2220" alt="Screenshot_20250929_122623" src="https://github.com/user-attachments/assets/79576d47-d469-4204-946e-688e8130d2f9" />|<img width="1080" height="2220" alt="Screenshot_20250929_122633" src="https://github.com/user-attachments/assets/165e667c-3f0a-40f5-86a4-1525cab4e9f5" />|
