### PR TITLE
Check is proxy is available on run start

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings-common.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings-common.xml
@@ -407,6 +407,7 @@
     <string name="Modal_AlwaysRun">Always Run</string>
     <string name="Modal_Error_CantDownloadURLs">Unable to download URL list. Please try again.</string>
     <string name="Modal_Error_NoInternet">No Internet connection</string>
+    <string name="Modal_Error_ProxyUnavailable">The selected proxy may be unavailable</string>
     <string name="Modal_CustomURL_Title_NotSaved">Are you sure?</string>
     <string name="Modal_CustomURL_NotSaved">Your URLs will not be saved when you leave this screen. Are you sure you want to leave this screen?</string>
     <string name="Modal_Autorun_BatteryOptimization_Onboarding">The application cannot run tests automatically without background permission. Do you want to try again?</string>

--- a/composeApp/src/commonMain/kotlin/org/ooni/engine/Engine.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/engine/Engine.kt
@@ -21,6 +21,7 @@ import org.ooni.probe.config.OrganizationConfig
 import org.ooni.probe.data.models.BatteryState
 import org.ooni.probe.data.models.InstalledTestDescriptorModel
 import org.ooni.probe.data.models.NetTest
+import org.ooni.probe.data.models.ProxyOption
 import org.ooni.probe.domain.CancelListenerCallback
 import org.ooni.probe.shared.PlatformInfo
 import kotlin.coroutines.CoroutineContext
@@ -124,9 +125,14 @@ class Engine(
         method: String,
         url: String,
         taskOrigin: TaskOrigin = TaskOrigin.OoniRun,
+        proxy: ProxyOption? = null,
     ): Result<String?, MkException> =
         resultOf(backgroundContext) {
-            val sessionConfig = buildSessionConfig(taskOrigin, getEnginePreferences())
+            var enginePreferences = getEnginePreferences()
+            if (proxy != null) {
+                enginePreferences = enginePreferences.copy(proxy = proxy.value)
+            }
+            val sessionConfig = buildSessionConfig(taskOrigin, enginePreferences)
             session(sessionConfig).use {
                 it
                     .httpDo(

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/data/models/TestRunError.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/data/models/TestRunError.kt
@@ -4,4 +4,6 @@ sealed interface TestRunError {
     data object DownloadUrlsFailed : TestRunError
 
     data object NoInternet : TestRunError
+
+    data object ProxyUnavailable : TestRunError
 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
@@ -436,6 +436,7 @@ class Dependencies(
             getEnginePreferences = getEnginePreferences::invoke,
             finishInProgressData = finishInProgressData::invoke,
             networkTypeFinder = networkTypeFinder::invoke,
+            testProxy = testProxy::invoke,
         )
     }
     private val saveTestDescriptors by lazy {
@@ -499,6 +500,7 @@ class Dependencies(
     private val testProxy by lazy {
         TestProxy(
             httpDo = engine::httpDo,
+            getProxyOption = proxyManager::selected,
             backgroundContext = backgroundContext,
         )
     }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/proxy/TestProxy.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/proxy/TestProxy.kt
@@ -2,6 +2,7 @@ package org.ooni.probe.domain.proxy
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
 import org.ooni.engine.Engine.MkException
 import org.ooni.engine.models.Result
@@ -11,14 +12,23 @@ import org.ooni.probe.data.models.ProxyOption
 import kotlin.coroutines.CoroutineContext
 
 class TestProxy(
-    val httpDo: suspend (String, String, TaskOrigin) -> Result<String?, MkException>,
+    val httpDo: suspend (String, String, TaskOrigin, ProxyOption?) -> Result<String?, MkException>,
+    private val getProxyOption: () -> Flow<ProxyOption>,
     private val backgroundContext: CoroutineContext,
 ) {
-    operator fun invoke(proxy: ProxyOption.Custom): Flow<State> =
+    operator fun invoke(proxyToTest: ProxyOption? = null): Flow<State> =
         channelFlow {
             send(State.Testing)
 
-            if (httpDo("GET", "https://api.ooni.org/health", TaskOrigin.OoniRun) is Success) {
+            val proxy = proxyToTest ?: getProxyOption().first()
+            if (proxy == ProxyOption.None) {
+                send(State.Available)
+                return@channelFlow
+            }
+
+            if (
+                httpDo("GET", "https://api.ooni.org/health", TaskOrigin.OoniRun, proxy) is Success
+            ) {
                 send(State.Available)
             } else {
                 send(State.Unavailable)

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/shared/TestRunErrorMessages.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/shared/TestRunErrorMessages.kt
@@ -3,8 +3,10 @@ package org.ooni.probe.ui.shared
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import ooniprobe.composeapp.generated.resources.Modal_Error_CantDownloadURLs
 import ooniprobe.composeapp.generated.resources.Modal_Error_NoInternet
+import ooniprobe.composeapp.generated.resources.Modal_Error_ProxyUnavailable
 import ooniprobe.composeapp.generated.resources.Res
 import org.jetbrains.compose.resources.getString
 import org.ooni.probe.LocalSnackbarHostState
@@ -19,15 +21,18 @@ fun TestRunErrorMessages(
     val snackbarHostState = LocalSnackbarHostState.current ?: return
     LaunchedEffect(errors) {
         val error = errors.firstOrNull() ?: return@LaunchedEffect
+        launch {
+            delay(2.seconds) // Shorter snackbar duration
+            onErrorDisplayed(error)
+        }
         snackbarHostState.showSnackbar(
             getString(
                 when (error) {
                     TestRunError.DownloadUrlsFailed -> Res.string.Modal_Error_CantDownloadURLs
                     TestRunError.NoInternet -> Res.string.Modal_Error_NoInternet
+                    TestRunError.ProxyUnavailable -> Res.string.Modal_Error_ProxyUnavailable
                 },
             ),
         )
-        delay(0.5.seconds) // No need to wait for the snackbar to be fully dismissed
-        onErrorDisplayed(error)
     }
 }


### PR DESCRIPTION
Also fixed 2 bugs:
- The proxy test was only checking the selected proxy, not the one in the argument
- The run test error snackbar was only being marked as seen 500ms after it was finished. I made it finish more quickly, so there's less chance of the user seeing it again.