### PR TITLE
Run tests in new thread

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunDescriptors.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunDescriptors.kt
@@ -63,6 +63,7 @@ class RunDescriptors(
             if (networkTypeFinder() == NetworkType.NoInternet) {
                 reportTestRunError(TestRunError.NoInternet)
             } else {
+                // Test the proxy asynchronously so that tests don't wait for it
                 coroutineScope {
                     launch {
                         if (testProxy().last() == TestProxy.State.Unavailable) {
@@ -74,7 +75,7 @@ class RunDescriptors(
 
             try {
                 runDescriptorsCancellable(descriptorsWithFinalInputs, spec)
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Exceptions were logged in the Engine
             } finally {
                 setRunBackgroundState { RunBackgroundState.Idle(LocalDateTime.now(), true) }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunNetTest.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/RunNetTest.kt
@@ -70,11 +70,15 @@ class RunNetTest(
             val installedDescriptorId =
                 (spec.descriptor.source as? Descriptor.Source.Installed)?.value?.id
 
-            startTest(
-                spec.netTest,
-                spec.taskOrigin,
-                installedDescriptorId,
-            ).collect(::onEvent)
+            try {
+                startTest(
+                    spec.netTest,
+                    spec.taskOrigin,
+                    installedDescriptorId,
+                ).collect(::onEvent)
+            } catch (_: Exception) {
+                // Exceptions were logged in the Engine
+            }
         }
     }
 


### PR DESCRIPTION
Run tests explicitly in a new thread, to see if it helps with handling native crashes. I also added error handling per individual test, so one test throwing an exception does not stop the entire run.