### PR TITLE
Fix iOS wrong markdown text color with workaround

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/shared/MarkdownViewer.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/shared/MarkdownViewer.kt
@@ -6,7 +6,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.style.TextDecoration
 import com.mikepenz.markdown.m3.Markdown
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
@@ -29,11 +32,13 @@ fun MarkdownViewer(
                 .copy(color = textColor),
             textLink = TextLinkStyles(
                 MaterialTheme.typography.bodyLarge
-                    .copy(color = linkColor)
+                    .copy(color = linkColor, textDecoration = TextDecoration.Underline)
                     .toSpanStyle(),
             ),
         ),
-        modifier = modifier,
+        modifier = modifier
+            // Fix text color issue on iOS: https://github.com/ooni/probe-multiplatform/issues/683
+            .graphicsLayer { colorFilter = ColorFilter.tint(textColor) },
         loading = { LinearProgressIndicator(modifier = modifier) },
     )
 }


### PR DESCRIPTION
The downside is that text links lose their primary color, so I made them underlined to compensate.

Closes #683 