### PR TITLE
Sign Sparkle and app manually

### DIFF
--- a/buildSrc/src/main/kotlin/ooni/sparkle/SetupSparkleTask.kt
+++ b/buildSrc/src/main/kotlin/ooni/sparkle/SetupSparkleTask.kt
@@ -69,10 +69,6 @@ abstract class SetupSparkleTask : DefaultTask() {
         project.exec {
             commandLine("cp", "-a", frameworkDir.absolutePath, dest.absolutePath)
         }
-        /*project.copy {
-            from(frameworkDir)
-            into(dest)
-        }*/
 
         versionMarker.writeText(versionStr)
         project.logger.lifecycle("Sparkle.framework is ready at ${dest.absolutePath}")


### PR DESCRIPTION
Closes #1002 

This works now, we just need to retry the github workflow:

```
./gradlew copyBrandingToCommonResources notarizeDmg -Porganization=ooni \
          -Pcompose.desktop.mac.sign=true \
          -Pcompose.desktop.mac.signing.identity="Open Observatory of Network Interference (OONI) ETS" \
          -Pcompose.desktop.mac.notarization.appleID=XXX \
          -Pcompose.desktop.mac.notarization.password=XXX \
          -Pcompose.desktop.mac.notarization.teamID=TT53HD8N84
```