### PR TITLE
Enable proguard and R8. Remove extra Android sentry dependencies.

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.api.variant.FilterConfiguration.FilterType.ABI
+import org.gradle.kotlin.dsl.exclude
 import java.time.LocalDate
 import org.jetbrains.compose.ExperimentalComposeLibrary
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
@@ -215,13 +216,18 @@ android {
             sourceSets["debug"].manifest.srcFile("src/androidDebug/AndroidManifest.xml")
         }
         getByName("release") {
-            isMinifyEnabled = false
             resValue("string", "run_v2_domain", "run.ooni.org")
             signingConfig = if (System.getenv("ANDROID_KEYSTORE_FILE") != null) {
                 signingConfigs.getByName("release")
             } else {
                 signingConfigs.getByName("debug")
             }
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
     buildFeatures {
@@ -505,4 +511,10 @@ version = android.defaultConfig.versionName ?: ""
 
 dependencies {
     debugImplementation(compose.uiTooling)
+}
+
+// Remove Sentry
+configurations.all {
+    exclude(group = "io.sentry", module = "sentry-android-ndk")
+    exclude(group = "io.sentry", module = "sentry-android-replay")
 }

--- a/composeApp/proguard-rules.pro
+++ b/composeApp/proguard-rules.pro
@@ -1,0 +1,1 @@
+-dontwarn io.sentry.android.replay.SessionReplayOptionsKt

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,7 @@ kotlin.apple.deprecated.allowUsingEmbedAndSignWithCocoaPodsDependencies=true
 # "This Android Gradle plugin (8.5.2) was tested up to compileSdk = 34."
 # But KMM doesn't support 8.6+ AGP yet, so let's suppress the warning for now
 android.suppressUnsupportedCompileSdk=35
+
+# Enable optimized resource shrinking
+# https://developer.android.com/topic/performance/app-optimization/enable-app-optimization#optimized-resource-shrinking-2
+android.r8.optimizedResourceShrinking=true


### PR DESCRIPTION
Around less 10MB in the final APKs.