### PR TITLE
Improve fetch descriptors concurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ output
 !composeApp/src/desktopMain/resources/linux/*.so
 !composeApp/src/desktopMain/resources/windows/*.dll
 composeApp/src/desktopMain/resources/windows/WinSparkle.*
+composeApp/src/desktopMain/resources/macos/Sparkle.framework
 
 /composeApp/src/desktopMain/frameworks/
 composeApp/macos-appcast.xml


### PR DESCRIPTION
Let's go with a small amount of concurrency (4), until we can check in bulk through the API.

Closes #1039 