### PR TITLE
Workaround so dependabot uses google maven repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
+registries:
+   maven-google:
+     type: maven-repository
+     url: "https://dl.google.com/dl/android/maven2/"
 updates:
   - package-ecosystem: gradle
     directory: "/"


### PR DESCRIPTION
Source: https://github.com/dependabot/dependabot-core/issues/6888#issuecomment-1539501116