### PR TITLE
Improve desktop websites: update JavaFX. Quit as a DialogWindow.

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,12 +1,18 @@
 name: 'Setup'
 description: 'Setup Java, checkout and setup gradle'
+
+inputs:
+  java_version:
+    required: false
+    default: '17'
+
 runs:
   using: "composite"
   steps:
-    - name: Set up JDK 17
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: ${{ inputs.java_version }}
         distribution: 'temurin'
 
     - name: Gradle cache

--- a/.github/workflows/desktop_make.yml
+++ b/.github/workflows/desktop_make.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Setup (repo action)
         uses: ./.github/actions/setup
+        with:
+          java_version: '23'
 
       - name: Cache Gradle
         uses: actions/cache@v4
@@ -102,6 +104,8 @@ jobs:
 
       - name: Setup (repo action)
         uses: ./.github/actions/setup
+        with:
+          java_version: '23'
 
       - name: Package Exe
         shell: pwsh
@@ -127,6 +131,8 @@ jobs:
 
       - name: Setup (repo action)
         uses: ./.github/actions/setup
+        with:
+          java_version: '23'
 
       - name: Package Deb
         run: ./gradlew copyBrandingToCommonResources packageDeb -Porganization=${{ env.ORGANIZATION }}

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -26,7 +26,7 @@ val organization: String? by project
 val config = Organization.fromKey(organization).config
 
 val javaFxParts = listOf("base", "graphics", "controls", "media", "web", "swing")
-val javaFxVersion = "17"
+val javaFxVersion = "25.0.2"
 
 kotlin {
     androidTarget {

--- a/composeApp/src/desktopMain/kotlin/org/ooni/probe/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/org/ooni/probe/Main.kt
@@ -1,29 +1,35 @@
 package org.ooni.probe
 
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ApplicationScope
+import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.Tray
 import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
+import androidx.compose.ui.window.rememberDialogState
 import androidx.compose.ui.window.rememberWindowState
 import co.touchlab.kermit.Logger
 import io.github.kdroidfilter.platformtools.darkmodedetector.isSystemInDarkMode
 import io.github.kdroidfilter.platformtools.darkmodedetector.windows.setWindowsAdaptiveTitleBar
 import io.github.vinceglb.autolaunch.AutoLaunch
-import java.awt.Desktop
-import java.awt.desktop.AppReopenedListener
-import java.awt.desktop.QuitEvent
-import java.awt.desktop.QuitResponse
-import java.awt.Dimension
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -33,6 +39,10 @@ import ooniprobe.composeapp.generated.resources.Dashboard_Running_Running
 import ooniprobe.composeapp.generated.resources.Dashboard_Running_Stopping_Title
 import ooniprobe.composeapp.generated.resources.Desktop_OpenApp
 import ooniprobe.composeapp.generated.resources.Desktop_Quit
+import ooniprobe.composeapp.generated.resources.Modal_Cancel
+import ooniprobe.composeapp.generated.resources.Modal_Hide
+import ooniprobe.composeapp.generated.resources.Modal_Quite_Description
+import ooniprobe.composeapp.generated.resources.Modal_Quite_Prompt
 import ooniprobe.composeapp.generated.resources.Res
 import ooniprobe.composeapp.generated.resources.Results_UploadingMissing
 import ooniprobe.composeapp.generated.resources.app_name
@@ -54,24 +64,18 @@ import org.ooni.probe.data.models.RunBackgroundState
 import org.ooni.probe.domain.UploadMissingMeasurements
 import org.ooni.probe.shared.DeepLinkParser
 import org.ooni.probe.shared.DesktopOS
-import org.ooni.probe.shared.createUpdateManager
 import org.ooni.probe.shared.InstanceManager
 import org.ooni.probe.shared.MacDockVisibility
 import org.ooni.probe.shared.Platform
 import org.ooni.probe.shared.UpdateState
-import org.ooni.probe.update.DesktopUpdateController
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.width
-import androidx.compose.ui.Modifier
-import ooniprobe.composeapp.generated.resources.Modal_Cancel
-import ooniprobe.composeapp.generated.resources.Modal_Hide
-import ooniprobe.composeapp.generated.resources.Modal_Quite_Description
-import ooniprobe.composeapp.generated.resources.Modal_Quite_Prompt
+import org.ooni.probe.shared.createUpdateManager
 import org.ooni.probe.ui.theme.AppTheme
+import org.ooni.probe.update.DesktopUpdateController
+import java.awt.Desktop
+import java.awt.Dimension
+import java.awt.desktop.AppReopenedListener
+import java.awt.desktop.QuitEvent
+import java.awt.desktop.QuitResponse
 
 const val APP_ID = "org.ooni.probe"
 
@@ -161,24 +165,31 @@ fun main(args: Array<String>) {
                         }
                     },
                 )
+            }
 
-                if (showQuitPrompt) {
-                    AppTheme {
-                        QuitPromptDialog(
-                            onQuit = {
-                                showQuitPrompt = false
-                                onQuitApplicationClicked(updateController, instanceManager).invoke()
-                            },
-                            onHide = {
-                                showQuitPrompt = false
-                                isWindowVisible = false
-                                MacDockVisibility.hideDockIcon()
-                            },
-                            onDismiss = {
-                                showQuitPrompt = false
-                            },
-                        )
-                    }
+            if (showQuitPrompt) {
+                DialogWindow(
+                    onCloseRequest = { showQuitPrompt = false },
+                    undecorated = true,
+                    transparent = true,
+                    resizable = false,
+                    alwaysOnTop = true,
+                    state = rememberDialogState(position = WindowPosition(Alignment.Center)),
+                ) {
+                    QuitPromptDialog(
+                        onQuit = {
+                            showQuitPrompt = false
+                            onQuitApplicationClicked(updateController, instanceManager).invoke()
+                        },
+                        onHide = {
+                            showQuitPrompt = false
+                            isWindowVisible = false
+                            MacDockVisibility.hideDockIcon()
+                        },
+                        onDismiss = {
+                            showQuitPrompt = false
+                        },
+                    )
                 }
             }
         }

--- a/composeApp/src/desktopMain/kotlin/org/ooni/probe/ui/shared/OoniWebView.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/org/ooni/probe/ui/shared/OoniWebView.desktop.kt
@@ -3,6 +3,7 @@ package org.ooni.probe.ui.shared
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.SwingPanel
+import co.touchlab.kermit.Logger
 import javafx.application.Platform
 import javafx.concurrent.Worker
 import javafx.embed.swing.JFXPanel
@@ -69,12 +70,15 @@ actual fun OoniWebView(
                                 }
 
                                 if (!allowed) {
-                                    engine.history.go(-1) // go back
-                                    // engine.load("about:blank")
                                     onDisallowedUrl(newLocation)
+                                    // Go back to the initial URL
+                                    engine.history.entries
+                                        .firstOrNull()
+                                        ?.let { engine.load(it.url) }
+                                        ?: engine.load("about:blank")
                                 }
                             } catch (e: Exception) {
-                                // Invalid URL, ignore
+                                Logger.w("Invalid URL $newLocation, ignoring", e)
                             }
                             controller.canGoBack = engine.history.currentIndex > 0
                         }


### PR DESCRIPTION
We lost some changes I had on the dashboard redesign branch. I updated the JavaFX even further and it improves a lot the Webview performance.

We were also having an issue with not being able to interact with the Quit AlertDialog on top of a webview. Now the quit dialog is in a separate window.