### PR TITLE
Use sample instead of debounce for more consistent log writes

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/shared/monitoring/AppLogger.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/shared/monitoring/AppLogger.kt
@@ -6,9 +6,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -60,7 +61,8 @@ class AppLogger(
                     if (log.value.isEmpty()) {
                         log.value = readFile(FILE_PATH).orEmpty().lines()
                     }
-                }.debounce(5.seconds)
+                }.sample(5.seconds)
+                .distinctUntilChanged()
                 .collectLatest { lines ->
                     writeFile(FILE_PATH, lines.joinToString("\n"), append = false)
                 }


### PR DESCRIPTION
I noticed that `debounce` was delaying too much the writing of logs to file. `sample` makes more sense here. We want regular writing to file, while avoid too frequent writes.