### PR TITLE
Optimize Articles and Urls bulk insertOrReplace

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/data/repositories/ArticleRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/data/repositories/ArticleRepository.kt
@@ -3,6 +3,7 @@ package org.ooni.probe.data.repositories
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import org.ooni.probe.Database
@@ -18,8 +19,12 @@ class ArticleRepository(
 ) {
     suspend fun refresh(models: List<ArticleModel>) {
         withContext(backgroundContext) {
+            val existing = list().first().toSet()
+            val newOrChanged = models - existing
+            val removedUrls = existing.map { it.url.value } - models.map { it.url.value }.toSet()
+
             database.transaction {
-                models.forEach { model ->
+                newOrChanged.forEach { model ->
                     database.articleQueries.insertOrReplace(
                         url = model.url.value,
                         title = model.title,
@@ -29,7 +34,7 @@ class ArticleRepository(
                         time = model.time.toEpoch(),
                     )
                 }
-                database.articleQueries.deleteExceptUrls(models.map { it.url.value })
+                database.articleQueries.deleteByUrl(removedUrls)
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/data/repositories/UrlRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/data/repositories/UrlRepository.kt
@@ -16,23 +16,24 @@ class UrlRepository(
     private val database: Database,
     private val backgroundContext: CoroutineContext,
 ) {
-    suspend fun createOrUpdate(model: UrlModel): UrlModel.Id =
+    suspend fun createOrUpdate(model: UrlModel): UrlModel =
         withContext(backgroundContext) {
             database.transactionWithResult {
                 createOrUpdateWithoutTransaction(model)
             }
         }
 
-    private fun createOrUpdateWithoutTransaction(model: UrlModel): UrlModel.Id {
+    private fun createOrUpdateWithoutTransaction(model: UrlModel): UrlModel {
         database.urlQueries.insertOrReplace(
             id = model.id?.value,
             url = model.url,
             country_code = model.countryCode,
             category_code = model.category.code,
         )
-
-        return model.id ?: UrlModel.Id(
-            database.urlQueries.selectLastInsertedRowId().executeAsOne(),
+        return model.copy(
+            id = model.id ?: UrlModel.Id(
+                database.urlQueries.selectLastInsertedRowId().executeAsOne(),
+            ),
         )
     }
 
@@ -48,22 +49,24 @@ class UrlRepository(
                         }.flatMap { list -> list.mapNotNull { it.toModel() } }
 
                 models.map { model ->
+                    // Already has ID, let's update
                     if (model.id != null) {
                         createOrUpdateWithoutTransaction(model)
-                        model
-                    } else {
-                        val existingModel = existingModels.firstOrNull { it.url == model.url }
+                        return@map model
+                    }
 
-                        if (existingModel != null) {
-                            val modelWithId = model.copy(id = existingModel.id)
-                            if (model != existingModel) {
-                                createOrUpdateWithoutTransaction(modelWithId)
-                            }
-                            modelWithId
-                        } else {
-                            val modelId = createOrUpdateWithoutTransaction(model)
-                            model.copy(id = modelId)
-                        }
+                    val existingModel = existingModels.firstOrNull { it.url == model.url }
+                    if (existingModel == null) {
+                        // New URL, let's insert
+                        return@map createOrUpdateWithoutTransaction(model)
+                    }
+
+                    // Existing URL, let's update if something changed
+                    val modelWithId = model.copy(id = existingModel.id)
+                    if (modelWithId != existingModel) {
+                        createOrUpdateWithoutTransaction(modelWithId)
+                    } else {
+                        existingModel
                     }
                 }
             }
@@ -79,7 +82,7 @@ class UrlRepository(
                     category = WebConnectivityCategory.MISC,
                     countryCode = null,
                 )
-                newModel.copy(id = createOrUpdate(newModel))
+                createOrUpdate(newModel)
             }
 
     fun list(): Flow<List<UrlModel>> =

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/descriptors/SaveTestDescriptors.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/descriptors/SaveTestDescriptors.kt
@@ -15,7 +15,7 @@ class SaveTestDescriptors(
         mode: Mode,
     ) {
         val webConnectivityUrls = models
-            .flatMap { it.netTests.orEmpty() }
+            .flatMap { it.netTests }
             .filter { it.test == TestType.WebConnectivity }
             .flatMap { it.inputs.orEmpty() }
             .map { url ->

--- a/composeApp/src/commonMain/sqldelight/org/ooni/probe/data/Article.sq
+++ b/composeApp/src/commonMain/sqldelight/org/ooni/probe/data/Article.sq
@@ -20,6 +20,6 @@ INSERT OR REPLACE INTO Article (
 selectAll:
 SELECT * FROM Article ORDER BY time DESC;
 
-deleteExceptUrls:
-DELETE FROM Article WHERE Article.url NOT IN ?;
+deleteByUrl:
+DELETE FROM Article WHERE Article.url IN ?;
 

--- a/composeApp/src/commonTest/kotlin/org/ooni/probe/data/repositories/UrlRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/probe/data/repositories/UrlRepositoryTest.kt
@@ -49,11 +49,11 @@ class UrlRepositoryTest {
         runTest {
             val model = UrlModelFactory.build(id = UrlModel.Id(Random.nextLong().absoluteValue))
 
-            val modelId = subject.createOrUpdate(model)
-            val result = subject.list().first().first()
+            val updateModel = subject.createOrUpdate(model)
+            val listModel = subject.list().first().first()
 
-            assertEquals(model.id, modelId)
-            assertEquals(model, result)
+            assertEquals(model, updateModel)
+            assertEquals(model, listModel)
         }
 
     @Test
@@ -105,11 +105,12 @@ class UrlRepositoryTest {
             val url = "htts://example.org"
             val model = UrlModelFactory.build(url = url)
 
-            val id = subject.createOrUpdate(model)
+            val createModel = subject.createOrUpdate(model)
             val result = subject.getOrCreateByUrl(url)
 
             assertNotNull(result)
+            assertNotNull(createModel.id)
             assertEquals(url, result.url)
-            assertEquals(id, result.id)
+            assertEquals(createModel.id, result.id)
         }
 }

--- a/composeApp/src/commonTest/kotlin/org/ooni/testing/factories/ArticleModelFactory.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/testing/factories/ArticleModelFactory.kt
@@ -12,7 +12,7 @@ object ArticleModelFactory {
         url: ArticleModel.Url = ArticleModel.Url("https://example.org/${Random.nextInt()}"),
         title: String = "Title",
         time: LocalDateTime = LocalDate.today().atTime(0, 0),
-        description: String? = null,
+        description: String? = Random.nextBytes(1024).toString(),
         imageUrl: String? = null,
         source: ArticleModel.Source = ArticleModel.Source.Blog,
     ) = ArticleModel(

--- a/composeApp/src/commonTest/kotlin/org/ooni/testing/factories/DatabaseHelper.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/testing/factories/DatabaseHelper.kt
@@ -102,9 +102,10 @@ class DatabaseHelper private constructor(
                 MeasurementModelFactory.build(
                     resultId = trustedId,
                     test = TestType.WebConnectivity,
-                    urlId = shared.dependency.urlRepository.createOrUpdate(
-                        UrlModelFactory.build(url = "https://www.dw.com"),
-                    ),
+                    urlId = shared.dependency.urlRepository
+                        .createOrUpdate(
+                            UrlModelFactory.build(url = "https://www.dw.com"),
+                        ).id,
                     reportId = MeasurementModel.ReportId("20250205T153106Z_webconnectivity_DE_3209_n1_iB2GPLBoLLpSlEYf"),
                     isDone = true,
                     isUploaded = true,
@@ -130,9 +131,10 @@ class DatabaseHelper private constructor(
                     MeasurementModelFactory.build(
                         resultId = trustedId,
                         test = TestType.WebConnectivity,
-                        urlId = shared.dependency.urlRepository.createOrUpdate(
-                            UrlModelFactory.build(url = url),
-                        ),
+                        urlId = shared.dependency.urlRepository
+                            .createOrUpdate(
+                                UrlModelFactory.build(url = url),
+                            ).id,
                         reportId = MeasurementModel.ReportId("12345"),
                         isDone = true,
                         isUploaded = true,
@@ -145,9 +147,10 @@ class DatabaseHelper private constructor(
                     MeasurementModelFactory.build(
                         resultId = selectedId,
                         test = TestType.WebConnectivity,
-                        urlId = shared.dependency.urlRepository.createOrUpdate(
-                            UrlModelFactory.build(url = "https://example.org"),
-                        ),
+                        urlId = shared.dependency.urlRepository
+                            .createOrUpdate(
+                                UrlModelFactory.build(url = "https://example.org"),
+                            ).id,
                         reportId = MeasurementModel.ReportId("12345"),
                         isDone = true,
                         isUploaded = true,
@@ -160,9 +163,10 @@ class DatabaseHelper private constructor(
                     MeasurementModelFactory.build(
                         resultId = globalId,
                         test = TestType.WebConnectivity,
-                        urlId = shared.dependency.urlRepository.createOrUpdate(
-                            UrlModelFactory.build(url = "https://example.org"),
-                        ),
+                        urlId = shared.dependency.urlRepository
+                            .createOrUpdate(
+                                UrlModelFactory.build(url = "https://example.org"),
+                            ).id,
                         reportId = MeasurementModel.ReportId("12345"),
                         isDone = true,
                         isUploaded = true,
@@ -188,9 +192,10 @@ class DatabaseHelper private constructor(
                 MeasurementModelFactory.build(
                     resultId = websitesResultId,
                     test = TestType.WebConnectivity,
-                    urlId = shared.dependency.urlRepository.createOrUpdate(
-                        UrlModelFactory.build(url = "https://z-lib.org/"),
-                    ),
+                    urlId = shared.dependency.urlRepository
+                        .createOrUpdate(
+                            UrlModelFactory.build(url = "https://z-lib.org/"),
+                        ).id,
                     reportId = MeasurementModel.ReportId("20250210T113750Z_webconnectivity_IT_12874_n1_qx1LFyoqM4orUsor"),
                     isDone = true,
                     isUploaded = true,
@@ -223,9 +228,10 @@ class DatabaseHelper private constructor(
                 shared.dependency.measurementRepository.createOrUpdate(
                     MeasurementModelFactory.build(
                         resultId = websitesResultId,
-                        urlId = shared.dependency.urlRepository.createOrUpdate(
-                            UrlModelFactory.build(url = url),
-                        ),
+                        urlId = shared.dependency.urlRepository
+                            .createOrUpdate(
+                                UrlModelFactory.build(url = url),
+                            ).id,
                         isDone = true,
                         isUploaded = true,
                         isAnomaly = false,
@@ -245,9 +251,10 @@ class DatabaseHelper private constructor(
                     MeasurementModelFactory.build(
                         resultId = websitesResultId,
                         test = TestType.WebConnectivity,
-                        urlId = shared.dependency.urlRepository.createOrUpdate(
-                            UrlModelFactory.build(url = url),
-                        ),
+                        urlId = shared.dependency.urlRepository
+                            .createOrUpdate(
+                                UrlModelFactory.build(url = url),
+                            ).id,
                         isDone = true,
                         isUploaded = true,
                         isAnomaly = true,

--- a/composeApp/src/commonTest/kotlin/org/ooni/testing/factories/UrlModelFactory.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/testing/factories/UrlModelFactory.kt
@@ -2,11 +2,12 @@ package org.ooni.testing.factories
 
 import org.ooni.engine.models.WebConnectivityCategory
 import org.ooni.probe.data.models.UrlModel
+import kotlin.random.Random
 
 object UrlModelFactory {
     fun build(
         id: UrlModel.Id? = null,
-        url: String = "https://ooni.org",
+        url: String = "https://ooni.org?random=${Random.nextLong()}",
         category: WebConnectivityCategory = WebConnectivityCategory.MISC,
         countryCode: String? = null,
     ) = UrlModel(


### PR DESCRIPTION
Sentry was complaining about the performance of some of our bulk queries:
- https://ooni.sentry.io/issues/7367486872/
- https://ooni.sentry.io/issues/7348615212/

So I optimized a bit the related operations:
- Minimized the amount of SQL queries on Articles.refresh
- Fixed a bug on the UrlRepository where models were always updates, even when they matched the ones on the DB.
- Simplified a bit the code inside UrlRepository