### PR TITLE
desktop: Debug build support

### DIFF
--- a/buildSrc/src/main/kotlin/BuildUtils.kt
+++ b/buildSrc/src/main/kotlin/BuildUtils.kt
@@ -17,13 +17,15 @@ fun Project.isFdroidTaskRequested(): Boolean =
 fun Project.isDebugTaskRequested(): Boolean {
     val isTaskDebug = gradle.startParameter.taskRequests
         .flatMap { it.args }
-        .any { it.contains("Debug") }
+        .any { it.contains("Debug") || it.contains("Run") }
+    logger.info("isTaskDebug=$isTaskDebug")
+
     if (isTaskDebug) return true
 
     return try {
         val properties = Properties()
         properties.load(project.rootProject.file("local.properties").inputStream())
-        println("forceDebug=${properties["forceDebug"]}")
+        logger.info("forceDebug=${properties["forceDebug"]}")
         properties["forceDebug"] == true || properties["forceDebug"] == "true"
     } catch (e: Exception) {
         e.printStackTrace()

--- a/buildSrc/src/main/kotlin/BuildUtils.kt
+++ b/buildSrc/src/main/kotlin/BuildUtils.kt
@@ -19,6 +19,7 @@ fun Project.isDebugTaskRequested(): Boolean {
         .flatMap { it.args }
         .any {
             it.contains("Debug") ||
+                it.contains("test", ignoreCase = true) ||
                 (it.contains("run", ignoreCase = true) && !it.contains("Release", ignoreCase = true))
         }
     logger.info("isTaskDebug=$isTaskDebug")

--- a/buildSrc/src/main/kotlin/BuildUtils.kt
+++ b/buildSrc/src/main/kotlin/BuildUtils.kt
@@ -17,7 +17,10 @@ fun Project.isFdroidTaskRequested(): Boolean =
 fun Project.isDebugTaskRequested(): Boolean {
     val isTaskDebug = gradle.startParameter.taskRequests
         .flatMap { it.args }
-        .any { it.contains("Debug") || it.contains("Run") }
+        .any {
+            it.contains("Debug") ||
+                (it.contains("run", ignoreCase = true) && !it.contains("Release", ignoreCase = true))
+        }
     logger.info("isTaskDebug=$isTaskDebug")
 
     if (isTaskDebug) return true

--- a/buildSrc/src/main/kotlin/BuildUtils.kt
+++ b/buildSrc/src/main/kotlin/BuildUtils.kt
@@ -1,6 +1,7 @@
 import org.gradle.api.Project
 import org.gradle.internal.os.OperatingSystem
 import java.io.File
+import java.util.Properties
 
 /**
  * Check if F-Droid build task is requested.
@@ -13,10 +14,22 @@ fun Project.isFdroidTaskRequested(): Boolean =
 /**
  * Check if Debug build task is requested.
  */
-fun Project.isDebugTaskRequested(): Boolean =
-    gradle.startParameter.taskRequests
+fun Project.isDebugTaskRequested(): Boolean {
+    val isTaskDebug = gradle.startParameter.taskRequests
         .flatMap { it.args }
         .any { it.contains("Debug") }
+    if (isTaskDebug) return true
+
+    return try {
+        val properties = Properties()
+        properties.load(project.rootProject.file("local.properties").inputStream())
+        println("forceDebug=${properties["forceDebug"]}")
+        properties["forceDebug"] == true || properties["forceDebug"] == "true"
+    } catch (e: Exception) {
+        e.printStackTrace()
+        false
+    }
+}
 
 /**
  * Get the appropriate JavaFX suffix for the current OS and architecture.

--- a/buildSrc/src/main/kotlin/TaskRegistration.kt
+++ b/buildSrc/src/main/kotlin/TaskRegistration.kt
@@ -307,12 +307,6 @@ private fun Project.configureTaskDependencies() {
         tasks.findByName("packageDmg")?.dependsOn(ooniDistributableTask)
         tasks.findByName("packageDistributionForCurrentOS")?.dependsOn(ooniDistributableTask)
         tasks.findByName("runDistributable")?.dependsOn(ooniDistributableTask)
-
-        // Mark run* tasks as debug builds.
-        // Packaged distributions (DMG, MSI, etc.) won't have this, so app.debug defaults to null (= release).
-        tasks.matching { it.name.startsWith("run") && it is JavaExec }.configureEach {
-            (this as JavaExec).jvmArgs("-Dapp.debug=true")
-        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/TaskRegistration.kt
+++ b/buildSrc/src/main/kotlin/TaskRegistration.kt
@@ -43,6 +43,47 @@ private fun Project.registerAndroidTasks(config: AppConfig) {
     }
 }
 
+/**
+ * Registers a task that generates DesktopBuildConfig.kt with version info
+ * baked into compiled code (replacing System.getProperty which requires JVM args).
+ *
+ * Must be called from the build script where Android extension values are available.
+ * The caller is also responsible for wiring the output to the desktopMain source set:
+ * ```
+ * kotlin.sourceSets.getByName("desktopMain") {
+ *     kotlin.srcDir(tasks.named("generateDesktopBuildConfig"))
+ * }
+ * ```
+ */
+fun Project.registerDesktopBuildConfigTask(
+    versionName: String,
+    versionCode: Int,
+) {
+    val isDebug = isDebugTaskRequested()
+    tasks.register("generateDesktopBuildConfig") {
+        val outputDir = layout.buildDirectory.dir("generated/desktopBuildConfig/kotlin")
+        inputs.property("versionName", versionName)
+        inputs.property("versionCode", versionCode)
+        inputs.property("isDebug", isDebug)
+        outputs.dir(outputDir)
+        doLast {
+            val dir = outputDir.get().asFile.resolve("org/ooni/probe")
+            dir.mkdirs()
+            dir.resolve("DesktopBuildConfig.kt").writeText(
+                """
+                |package org.ooni.probe
+                |
+                |object DesktopBuildConfig {
+                |    const val VERSION_NAME = "$versionName"
+                |    const val VERSION_CODE = $versionCode
+                |    const val IS_DEBUG = $isDebug
+                |}
+                """.trimMargin(),
+            )
+        }
+    }
+}
+
 private fun Project.registerDesktopTasks() {
     tasks.register("makeLibrary", Exec::class) {
         group = "ooni"

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -493,14 +493,6 @@ compose.desktop {
                 iconFile.set(rootProject.file("icons/app.png"))
             }
         }
-
-        // Pass properties to the JVM when running from Gradle
-        jvmArgs += listOf(
-            "-Dapp.version.name=${android.defaultConfig.versionName}",
-            "-Dapp.version.code=${android.defaultConfig.versionCode}",
-            "-Dapp.version.code=${android.defaultConfig.versionCode}",
-            "-Dapp.debug=${isDebugTaskRequested()}",
-        )
     }
 }
 
@@ -571,6 +563,14 @@ compose.resources {
 }
 
 version = android.defaultConfig.versionName ?: ""
+
+registerDesktopBuildConfigTask(
+    versionName = android.defaultConfig.versionName ?: "1.0.0",
+    versionCode = android.defaultConfig.versionCode ?: 0,
+)
+kotlin.sourceSets.getByName("desktopMain") {
+    kotlin.srcDir(tasks.named("generateDesktopBuildConfig"))
+}
 
 dependencies {
     debugImplementation(libs.compose.ui.tooling)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -498,6 +498,8 @@ compose.desktop {
         jvmArgs += listOf(
             "-Dapp.version.name=${android.defaultConfig.versionName}",
             "-Dapp.version.code=${android.defaultConfig.versionCode}",
+            "-Dapp.version.code=${android.defaultConfig.versionCode}",
+            "-Dapp.debug=${isDebugTaskRequested()}",
         )
     }
 }

--- a/composeApp/src/desktopMain/kotlin/org/ooni/probe/BuildDependencies.kt
+++ b/composeApp/src/desktopMain/kotlin/org/ooni/probe/BuildDependencies.kt
@@ -64,9 +64,9 @@ val dependencies = Dependencies(
 
 private fun buildPlatformInfo(): PlatformInfo {
     val osVersion = System.getProperty("os.version")
-    val buildName = System.getProperty("app.version.name")?.ifBlank { null } ?: "1.0.0"
-    val buildNumber = System.getProperty("app.version.code")?.ifBlank { null } ?: "0"
-    val isDebug = System.getProperty("app.debug")?.toBoolean() ?: true
+    val buildName = DesktopBuildConfig.VERSION_NAME
+    val buildNumber = DesktopBuildConfig.VERSION_CODE.toString()
+    val isDebug = DesktopBuildConfig.IS_DEBUG
     val environment = if (isDebug) "development" else "production"
 
     return PlatformInfo(

--- a/composeApp/src/desktopMain/kotlin/org/ooni/probe/BuildDependencies.kt
+++ b/composeApp/src/desktopMain/kotlin/org/ooni/probe/BuildDependencies.kt
@@ -66,7 +66,7 @@ private fun buildPlatformInfo(): PlatformInfo {
     val osVersion = System.getProperty("os.version")
     val buildName = System.getProperty("app.version.name")?.ifBlank { null } ?: "1.0.0"
     val buildNumber = System.getProperty("app.version.code")?.ifBlank { null } ?: "0"
-    val isDebug = System.getProperty("app.debug")?.toBoolean() ?: false
+    val isDebug = System.getProperty("app.debug")?.toBoolean() ?: true
     val environment = if (isDebug) "development" else "production"
 
     return PlatformInfo(


### PR DESCRIPTION
Closes #1281

@aanorbel what do you think of this approach? It works for iOS as well. And we can expand it to change the desktop app name, the folder, etc..