### PR TITLE
Handle empty measurementUid responses

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/SubmitMeasurement.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/SubmitMeasurement.kt
@@ -34,7 +34,9 @@ class SubmitMeasurement(
                     isUploadFailed = false,
                     uploadFailureMessage = null,
                     reportId = MeasurementModel.ReportId(result.value.updatedReportId),
-                    uid = result.value.measurementUid?.let(MeasurementModel::Uid),
+                    uid = result.value.measurementUid
+                        ?.ifBlank { null }
+                        ?.let(MeasurementModel::Uid),
                 )
                 updateMeasurement(newMeasurement)
                 deleteFiles(reportFilePath)

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/measurement/MeasurementViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/measurement/MeasurementViewModel.kt
@@ -75,7 +75,7 @@ class MeasurementViewModel(
     private fun MeasurementWithUrl.getWebViewUrl(): String? {
         val m = measurement
         val input = url?.url
-        return if (m.uid != null) {
+        return if (m.uid != null && m.uid.value.isNotBlank()) {
             "${OrganizationConfig.explorerUrl}/m/${m.uid.value}?webview=true&language=${Locale.current.language}-${Locale.current.region}"
         } else if (m.reportId != null) {
             val inputSuffix = input?.let { "?input=${urlEncode(it)}" } ?: ""


### PR DESCRIPTION
This was happening on the `dev` environment but it's better to protect against this happening. It should fallback to using the reportId for showing the measurement page.