### PR TITLE
Make instrumented tests wait for bootstrap

### DIFF
--- a/composeApp/src/androidInstrumentedTest/kotlin/org/ooni/probe/uitesting/SettingsTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/org/ooni/probe/uitesting/SettingsTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.flow.first
@@ -50,6 +49,7 @@ import org.ooni.probe.uitesting.helpers.preferences
 import org.ooni.probe.uitesting.helpers.skipOnboarding
 import org.ooni.probe.uitesting.helpers.start
 import org.ooni.probe.uitesting.helpers.wait
+import org.ooni.probe.uitesting.helpers.waitAssertion
 import kotlin.time.Duration.Companion.seconds
 
 @RunWith(AndroidJUnit4::class)
@@ -210,12 +210,17 @@ class SettingsTest {
                 wait { preferences.getValueByKey(SettingsKey.WARN_VPN_IN_USE).first() == true }
 
                 clickOnText(Res.string.Settings_Results_DeleteOldResults)
+                wait { preferences.getValueByKey(SettingsKey.DELETE_OLD_RESULTS).first() == false }
+                clickOnText(Res.string.Settings_Results_DeleteOldResults)
                 wait { preferences.getValueByKey(SettingsKey.DELETE_OLD_RESULTS).first() == true }
 
                 clickOnText(Res.string.Settings_Results_DeleteOldResultsThreshold)
-                onNodeWithTag("NumberPickerField").performTextInput("8")
+                waitAssertion { onNodeWithTag("NumberPickerField").assertIsDisplayed() }
+                onNodeWithTag("NumberPickerField").performTextReplacement("8")
                 clickOnText(Res.string.Modal_OK)
-                wait { preferences.getValueByKey(SettingsKey.DELETE_OLD_RESULTS_THRESHOLD).first() == 8 }
+                wait {
+                    preferences.getValueByKey(SettingsKey.DELETE_OLD_RESULTS_THRESHOLD).first() == 8
+                }
             }
         }
 }

--- a/composeApp/src/androidInstrumentedTest/kotlin/org/ooni/probe/uitesting/helpers/StateTestHelpers.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/org/ooni/probe/uitesting/helpers/StateTestHelpers.kt
@@ -1,10 +1,25 @@
 package org.ooni.probe.uitesting.helpers
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.ooni.probe.data.models.SettingsKey
 import org.ooni.probe.domain.organizationPreferenceDefaults
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+
+suspend fun waitForBootstrap() {
+    withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(3.seconds) {
+            preferences.getValueByKey(SettingsKey.FIRST_RUN).filter { it != null }.first()
+        }
+    }
+}
 
 suspend fun skipOnboarding() {
+    waitForBootstrap()
     preferences.setValuesByKey(
         listOf(
             SettingsKey.FIRST_RUN to false,


### PR DESCRIPTION
Now that our Initialization runs on app start, and not app open, it has a race condition with our `skipOnboarding`. Now it should wait for BoostrapPreferences to finish at least.