### PR TITLE
Refactor measurement url and improve locale string

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/data/models/MeasurementWithUrl.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/data/models/MeasurementWithUrl.kt
@@ -1,6 +1,30 @@
 package org.ooni.probe.data.models
 
+import androidx.compose.ui.text.intl.Locale
+import io.ktor.http.URLBuilder
+import io.ktor.http.appendPathSegments
+import org.ooni.probe.config.OrganizationConfig
+import org.ooni.probe.shared.languageRegionString
+
 data class MeasurementWithUrl(
     val measurement: MeasurementModel,
     val url: UrlModel?,
-)
+) {
+    val webViewUrl: String?
+        get() {
+            val webViewUrl = URLBuilder(OrganizationConfig.explorerUrl)
+            if (measurement.uid != null && measurement.uid.value.isNotBlank()) {
+                webViewUrl.appendPathSegments(listOf("m", measurement.uid.value))
+            } else if (measurement.reportId != null) {
+                webViewUrl.appendPathSegments(listOf("measurement", measurement.reportId.value))
+                url?.url?.let {
+                    webViewUrl.parameters.append("input", it)
+                }
+            } else {
+                return null
+            }
+            webViewUrl.parameters.append("webview", "true")
+            webViewUrl.parameters.append("language", Locale.current.languageRegionString)
+            return webViewUrl.build().toString()
+        }
+}

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/shared/LocaleExt.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/shared/LocaleExt.kt
@@ -1,0 +1,6 @@
+package org.ooni.probe.shared
+
+import androidx.compose.ui.text.intl.Locale
+
+val Locale.languageRegionString
+    get() = language + region.ifBlank { null }?.let { "-$it" }.orEmpty()

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/measurement/MeasurementViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/measurement/MeasurementViewModel.kt
@@ -1,6 +1,5 @@
 package org.ooni.probe.ui.measurement
 
-import androidx.compose.ui.text.intl.Locale
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.Flow
@@ -12,8 +11,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import org.intellij.markdown.html.urlEncode
-import org.ooni.probe.config.OrganizationConfig
 import org.ooni.probe.data.models.MeasurementModel
 import org.ooni.probe.data.models.MeasurementWithUrl
 
@@ -33,7 +30,7 @@ class MeasurementViewModel(
     init {
         viewModelScope.launch {
             val measurement = getMeasurement(measurementId).first()
-            val url = measurement?.getWebViewUrl() ?: run {
+            val url = measurement?.webViewUrl ?: run {
                 onBack()
                 return@launch
             }
@@ -70,20 +67,6 @@ class MeasurementViewModel(
 
     fun onEvent(event: Event) {
         events.tryEmit(event)
-    }
-
-    private fun MeasurementWithUrl.getWebViewUrl(): String? {
-        val m = measurement
-        val input = url?.url
-        return if (m.uid != null && m.uid.value.isNotBlank()) {
-            "${OrganizationConfig.explorerUrl}/m/${m.uid.value}?webview=true&language=${Locale.current.language}-${Locale.current.region}"
-        } else if (m.reportId != null) {
-            val inputSuffix = input?.let { "?input=${urlEncode(it)}" } ?: ""
-            val separator = if (inputSuffix.isEmpty()) "?" else "&"
-            "${OrganizationConfig.explorerUrl}/measurement/${m.reportId.value}$inputSuffix${separator}webview=true&language=${Locale.current.language}-${Locale.current.region}"
-        } else {
-            null
-        }
     }
 
     sealed interface State {

--- a/composeApp/src/commonTest/kotlin/org/ooni/probe/data/models/MeasurementWithUrlTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/probe/data/models/MeasurementWithUrlTest.kt
@@ -1,0 +1,73 @@
+package org.ooni.probe.data.models
+
+import androidx.compose.ui.text.intl.Locale
+import org.ooni.probe.config.OrganizationConfig
+import org.ooni.probe.shared.languageRegionString
+import org.ooni.testing.factories.MeasurementModelFactory
+import org.ooni.testing.factories.UrlModelFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MeasurementWithUrlTest {
+    @Test
+    fun withoutUidButWithReportId() {
+        assertEquals(
+            "${OrganizationConfig.explorerUrl}/measurement/REPORT?webview=true&language=${Locale.current.languageRegionString}",
+            MeasurementWithUrl(
+                measurement = MeasurementModelFactory.build(
+                    uid = null,
+                    reportId = MeasurementModel.ReportId("REPORT"),
+                ),
+                url = null,
+            ).webViewUrl,
+        )
+        assertEquals(
+            "${OrganizationConfig.explorerUrl}/measurement/REPORT?input=https%3A%2F%2Fexample.org&webview=true&language=${Locale.current.languageRegionString}",
+            MeasurementWithUrl(
+                measurement = MeasurementModelFactory.build(
+                    uid = null,
+                    reportId = MeasurementModel.ReportId("REPORT"),
+                ),
+                url = UrlModelFactory.build(url = "https://example.org"),
+            ).webViewUrl,
+        )
+    }
+
+    @Test
+    fun withUid() {
+        assertEquals(
+            "${OrganizationConfig.explorerUrl}/m/MUID?webview=true&language=${Locale.current.languageRegionString}",
+            MeasurementWithUrl(
+                measurement = MeasurementModelFactory.build(
+                    uid = MeasurementModel.Uid("MUID"),
+                    reportId = MeasurementModel.ReportId("REPORT"),
+                ),
+                url = null,
+            ).webViewUrl,
+        )
+        assertEquals(
+            "${OrganizationConfig.explorerUrl}/m/MUID?webview=true&language=${Locale.current.languageRegionString}",
+            MeasurementWithUrl(
+                measurement = MeasurementModelFactory.build(
+                    uid = MeasurementModel.Uid("MUID"),
+                    reportId = MeasurementModel.ReportId("REPORT"),
+                ),
+                url = UrlModelFactory.build(url = "https://example.org"),
+            ).webViewUrl,
+        )
+    }
+
+    @Test
+    fun withNone() {
+        assertNull(
+            MeasurementWithUrl(
+                measurement = MeasurementModelFactory.build(
+                    uid = null,
+                    reportId = null,
+                ),
+                url = null,
+            ).webViewUrl,
+        )
+    }
+}


### PR DESCRIPTION
We were building URLs that could have weird things like `language=ja-` so I ended up refactoring that code and adding tests.