### PR TITLE
Upgrade to Java 25

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ description: 'Setup Java, checkout and setup gradle'
 inputs:
   java_version:
     required: false
-    default: '17'
+    default: '25'
 
 runs:
   using: "composite"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: ${{ inputs.java_version }}
         distribution: 'temurin'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: actions/setup-java@v5
       with:
         java-version: ${{ inputs.java_version }}
-        distribution: 'temurin'
+        distribution: 'corretto'
 
     - name: Gradle cache
       uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Build docs
         run: make docs
@@ -16,7 +16,7 @@ jobs:
         run: echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Checkout ooni/docs
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           repository: "ooni/docs"
           ssh-key: ${{ secrets.OONI_DOCS_DEPLOYKEY }}

--- a/.github/workflows/build_native_libraries.yml
+++ b/.github/workflows/build_native_libraries.yml
@@ -21,10 +21,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -45,7 +45,7 @@ jobs:
         run: ./gradlew makeLibrary
 
       - name: Upload built library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: networktypefinder-${{ matrix.os }}
           path: composeApp/src/desktopMain/resources/

--- a/.github/workflows/desktop_make.yml
+++ b/.github/workflows/desktop_make.yml
@@ -94,7 +94,7 @@ jobs:
       ORGANIZATION: ooni
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup (repo action)
         uses: ./.github/actions/setup
@@ -147,7 +147,7 @@ jobs:
 
       - name: Upload direct artifacts
         if: matrix.distribution == 'direct'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: desktopApps-macos-${{ github.run_id }}
           path: |
@@ -158,7 +158,7 @@ jobs:
 
       - name: Upload Mac App Store artifact
         if: matrix.distribution == 'mac-appstore'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: desktopApps-macos-appstore-${{ github.run_id }}
           path: |
@@ -167,7 +167,7 @@ jobs:
 
       - name: Upload failure diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: failure-logs-macos-${{ matrix.distribution }}-${{ github.run_id }}
           path: |
@@ -191,7 +191,7 @@ jobs:
       ORGANIZATION: ooni
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup (repo action)
         uses: ./.github/actions/setup
@@ -211,7 +211,7 @@ jobs:
 
       - name: Upload direct artifacts
         if: matrix.distribution == 'direct'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: desktopApps-windows-${{ github.run_id }}
           path: |
@@ -220,7 +220,7 @@ jobs:
 
       - name: Upload Microsoft Store artifact
         if: matrix.distribution == 'ms-store'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: desktopApps-windows-appstore-${{ github.run_id }}
           path: |
@@ -229,7 +229,7 @@ jobs:
 
       - name: Upload failure diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: failure-logs-windows-${{ matrix.distribution }}-${{ github.run_id }}
           path: |
@@ -249,7 +249,7 @@ jobs:
       ORGANIZATION: ooni
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup (repo action)
         uses: ./.github/actions/setup
@@ -267,7 +267,7 @@ jobs:
         run: ./gradlew copyBrandingToCommonResources packageAppImage -Porganization=${{ env.ORGANIZATION }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: desktopApps-linux-${{ github.run_id }}
           path: |
@@ -277,7 +277,7 @@ jobs:
 
       - name: Upload failure diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: failure-logs-linux-${{ github.run_id }}
           path: |

--- a/.github/workflows/desktop_make.yml
+++ b/.github/workflows/desktop_make.yml
@@ -98,8 +98,6 @@ jobs:
 
       - name: Setup (repo action)
         uses: ./.github/actions/setup
-        with:
-          java_version: '23'
 
       - name: Cache Gradle
         uses: actions/cache@v4
@@ -197,8 +195,6 @@ jobs:
 
       - name: Setup (repo action)
         uses: ./.github/actions/setup
-        with:
-          java_version: '23'
 
       - name: Package Exe (direct)
         if: matrix.distribution == 'direct'
@@ -257,8 +253,6 @@ jobs:
 
       - name: Setup (repo action)
         uses: ./.github/actions/setup
-        with:
-          java_version: '23'
 
       - name: Package Deb
         run: ./gradlew copyBrandingToCommonResources packageDeb -Porganization=${{ env.ORGANIZATION }}

--- a/.github/workflows/promote_android_on_google_play.yml
+++ b/.github/workflows/promote_android_on_google_play.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/publish_android_on_google_play.yml
+++ b/.github/workflows/publish_android_on_google_play.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -67,7 +67,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/publish_android_on_huawei.yml
+++ b/.github/workflows/publish_android_on_huawei.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/release_notifications.yml
+++ b/.github/workflows/release_notifications.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Slack Notification
         env:

--- a/.github/workflows/run_android_instrumented_tests.yml
+++ b/.github/workflows/run_android_instrumented_tests.yml
@@ -23,7 +23,7 @@ jobs:
             organization: dw
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/update_apple_app_store.yml
+++ b/.github/workflows/update_apple_app_store.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -44,7 +44,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/update_google_play.yml
+++ b/.github/workflows/update_google_play.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -47,7 +47,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
         variant: [ fdroid, full ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -33,7 +33,7 @@ jobs:
           }
 
       - name: Uploads test reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: android-lint-${{ matrix.variant }}-report
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -54,7 +54,7 @@ jobs:
         run: ./gradlew copyBrandingToCommonResources ktlintCheck
 
       - name: Uploads test reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: kotlin-lint-report
@@ -70,7 +70,7 @@ jobs:
         organization: [ ooni, dw ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -79,7 +79,7 @@ jobs:
         run: ./gradlew copyBrandingToCommonResources :composeApp:desktopTest -Porganization=${{ matrix.organization }}
 
       - name: Uploads test reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: common-tests-report-${{ matrix.organization }}
@@ -95,7 +95,7 @@ jobs:
         organization: [ ooni, dw ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -124,7 +124,7 @@ jobs:
         run: ./gradlew copyBrandingToCommonResources assembleFullRelease -Porganization=${{ matrix.organization }}
 
       - name: Upload APK artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.organization }}-release-APK
           path: composeApp/build/outputs/apk/full/release/composeApp-full-universal-release.apk
@@ -148,7 +148,7 @@ jobs:
         organization: [ ooni, dw ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -189,7 +189,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -198,10 +198,23 @@ jobs:
         run: ./gradlew copyBrandingToCommonResources packageDistributionForCurrentOS
 
       - name: Uploads artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DesktopApp
           path: composeApp/build/compose/binaries/**/**/*
+          retention-days: 7
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: failure-logs-macos-${{ matrix.distribution }}-${{ github.run_id }}
+          path: |
+            composeApp/build/compose/logs/**
+            composeApp/build/compose/tmp/**
+            composeApp/build/reports/problems/**
+            build/reports/problems/**
+          if-no-files-found: ignore
           retention-days: 7
 
   distribute:
@@ -213,13 +226,13 @@ jobs:
       matrix:
         organization: [ ooni, dw ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup
         uses: ./.github/actions/setup
 
       - name: Download APK artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ matrix.organization }}-release-APK
           path: composeApp/build/outputs/apk/full/release/

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -26,13 +26,13 @@ val organization: String? by project
 val config = Organization.fromKey(organization).config
 
 val javaFxParts = listOf("base", "graphics", "controls", "media", "web", "swing")
-val javaFxVersion = "25.0.2"
+val javaFxVersion = "26.0.1"
 
 kotlin {
     androidTarget {
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
+            jvmTarget.set(JvmTarget.JVM_25)
         }
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         instrumentedTestVariant {
@@ -244,8 +244,8 @@ android {
         compose = true
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_25
+        targetCompatibility = JavaVersion.VERSION_25
         isCoreLibraryDesugaringEnabled = true
     }
     sourceSets["main"].resources.setSrcDirs(


### PR DESCRIPTION
Closes #1323 

Bug fixed on JavaFX 26: https://bugs.openjdk.org/browse/JDK-8334593

Android build complains with `Kotlin does not yet support 25 JDK target, falling back to Kotlin JVM_24 JVM target`. But the Kotlin version 2.3 already supports Java 25. It may be the Kotlin version that's embedded in Gradle 9.3, which is still 2.2. 🤷 

But it runs fine on both Android and Desktop.