### PR TITLE
Avoid duplicate desktop update error reports

### DIFF
--- a/composeApp/src/desktopMain/kotlin/org/ooni/probe/update/DesktopUpdateController.kt
+++ b/composeApp/src/desktopMain/kotlin/org/ooni/probe/update/DesktopUpdateController.kt
@@ -54,12 +54,11 @@ class DesktopUpdateController(
 
                     when (error.code) {
                         -3, -4 -> {
+                            Logger.i("Current key: ${UpdateConfig.PUBLIC_KEY.take(20)}...")
                             Logger.e("EdDSA key validation failed. Please check SPARKLE_PUBLIC_KEY configuration.")
-                            Logger.e("Current key: ${UpdateConfig.PUBLIC_KEY.take(20)}...")
                         }
                         -1 -> {
                             Logger.w("Network or URL error. Update check will be retried automatically.")
-                            Logger.w("Appcast URL: ${UpdateConfig.URL}")
                         }
                         -999 -> {
                             Logger.e("Update system setup or validation error: ${error.message}")


### PR DESCRIPTION
Double Logger.w/e means 2 different reports on Sentry. We just need one. And Appcast URL was already logged earlier.

<img width="765" height="156" alt="Screenshot 2026-05-18 at 11 23 12" src="https://github.com/user-attachments/assets/ed86850c-5a7e-44bf-9b3f-317d6576fe8d" />
