### PR TITLE
Don't keep XML instance

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/articles/GetRSSFeed.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/articles/GetRSSFeed.kt
@@ -33,7 +33,7 @@ class GetRSSFeed(
                 if (response.isNullOrBlank()) return@flatMap Failure(Exception("Empty response"))
 
                 val rss = try {
-                    Xml.decodeFromString<Rss>(response)
+                    xml().decodeFromString<Rss>(response)
                 } catch (e: Exception) {
                     return@flatMap Failure(e)
                 }
@@ -76,13 +76,12 @@ class GetRSSFeed(
             ).toLocalDateTime()
 
     companion object Companion {
-        private val Xml by lazy {
+        private fun xml() =
             XML {
                 defaultPolicy {
                     ignoreUnknownChildren()
                 }
             }
-        }
     }
 
     @Serializable


### PR DESCRIPTION
The Android Studio profiler said this was using 500KB of 8MB of our heap space. So I tried no longer caching it, and the app is now using only 6.2MB. This is also something we don't use all the time, so I feel this is fine like this.