### PR TITLE
Avoid an empty string with the duration is zero

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/shared/DateFormats.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/shared/DateFormats.kt
@@ -98,7 +98,7 @@ fun Duration.format(abbreviated: Boolean = true): String =
             } else {
                 null
             },
-            if (seconds > 0) {
+            if (seconds > 0 || inWholeSeconds == 0L) {
                 if (abbreviated) {
                     stringResource(Res.string.Common_Seconds_Abbreviated, seconds)
                 } else {

--- a/composeApp/src/commonTest/kotlin/org/ooni/probe/ui/shared/DateFormatsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/probe/ui/shared/DateFormatsTest.kt
@@ -1,0 +1,24 @@
+package org.ooni.probe.ui.shared
+
+import androidx.compose.ui.test.v2.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class DateFormatsTest {
+    @Test
+    fun format() =
+        runComposeUiTest {
+            setContent {
+                assertEquals("0s", 0.seconds.format(abbreviated = true))
+                assertEquals("1s", 1.seconds.format(abbreviated = true))
+                assertEquals("1m", 1.minutes.format(abbreviated = true))
+                assertEquals("1m 1s", 61.seconds.format(abbreviated = true))
+                assertEquals("1 minute 1 second", 61.seconds.format(abbreviated = false))
+                assertEquals("2 minutes 2 seconds", 122.seconds.format(abbreviated = false))
+                assertEquals("1 hour", 1.hours.format(abbreviated = false))
+            }
+        }
+}


### PR DESCRIPTION
Our dashboard was showing "Estimated time left: " without a duration in front when it rounded to zero. It felt weird, I think it's better to show `0s`.