### PR TITLE
chore(engine,passport): depricate engine.httpDo in favor of `PassportGet`

### DIFF
--- a/androidApp/src/androidTest/kotlin/org/ooni/probe/uitesting/DescriptorsTest.kt
+++ b/androidApp/src/androidTest/kotlin/org/ooni/probe/uitesting/DescriptorsTest.kt
@@ -34,7 +34,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.ooni.engine.OonimkallBridge
+import org.ooni.engine.models.Success
+import org.ooni.passport.models.PassportHttpResponse
 import org.ooni.probe.MainActivity
 import org.ooni.probe.uitesting.helpers.TestFixtures
 import org.ooni.probe.uitesting.helpers.clickOnText
@@ -64,34 +65,35 @@ class DescriptorsTest {
         runTest {
             skipOnboarding()
             disableRefreshArticles()
-            installDescriptorEngine()
+            installDescriptorFixtures()
         }
 
     /**
-     * Serves the OONI Run descriptor offline. Before [publishDescriptorUpdate]
-     * the link returns revision 1 ("Testing"); afterwards revision 2
-     * ("Testing 2"), driving the auto-update flow without any network.
+     * Serves the OONI Run descriptor offline through the Passport bridge (which
+     * [org.ooni.probe.domain.descriptors.FetchDescriptor] now uses). Before
+     * [publishDescriptorUpdate] the link returns revision 1 ("Testing");
+     * afterwards revision 2 ("Testing 2"), driving the auto-update flow without
+     * any network.
      */
-    private fun installDescriptorEngine() {
+    private fun installDescriptorFixtures() {
         descriptorUpdatePublished = false
-        setupMockedEngine {
-            httpDo = { request ->
-                val body = when {
-                    request.url.endsWith(TestFixtures.DESCRIPTOR_REVISIONS_PATH) ->
-                        TestFixtures.DESCRIPTOR_REVISIONS_JSON
+        setupMockedEngine()
+        dependencies.passportGet = { url, _, _, _, _ ->
+            val body = when {
+                url.endsWith(TestFixtures.DESCRIPTOR_REVISIONS_PATH) ->
+                    TestFixtures.DESCRIPTOR_REVISIONS_JSON
 
-                    request.url.endsWith(TestFixtures.DESCRIPTOR_LINK_PATH) ->
-                        if (descriptorUpdatePublished) {
-                            TestFixtures.UPDATED_DESCRIPTOR_JSON
-                        } else {
-                            TestFixtures.ORIGINAL_DESCRIPTOR_JSON
-                        }
+                url.endsWith(TestFixtures.DESCRIPTOR_LINK_PATH) ->
+                    if (descriptorUpdatePublished) {
+                        TestFixtures.UPDATED_DESCRIPTOR_JSON
+                    } else {
+                        TestFixtures.ORIGINAL_DESCRIPTOR_JSON
+                    }
 
-                    else ->
-                        throw IllegalStateException("Response not mocked for ${request.url}")
-                }
-                OonimkallBridge.HTTPResponse(body = body)
+                else ->
+                    throw IllegalStateException("Response not mocked for $url")
             }
+            Success(PassportHttpResponse(200, "HTTP/1.1", emptyList(), body))
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/di/Dependencies.kt
@@ -18,9 +18,12 @@ import org.ooni.engine.NetworkTypeFinder
 import org.ooni.engine.OonimkallBridge
 import org.ooni.engine.SecureStorage
 import org.ooni.engine.TaskEventMapper
+import org.ooni.engine.models.Result
 import org.ooni.passport.PassportBridge
+import org.ooni.passport.models.PassportException
+import org.ooni.passport.models.PassportHttpResponse
 import org.ooni.probe.Database
-import org.ooni.probe.DesktopBuildConfig
+import org.ooni.probe.SharedBuildConfig
 import org.ooni.probe.background.RunBackgroundTask
 import org.ooni.probe.config.BatteryOptimization
 import org.ooni.probe.config.FlavorConfigInterface
@@ -182,7 +185,7 @@ class Dependencies(
     val proxyConfig: ProxyConfig,
     val getCountryNameByCode: (String) -> String,
     val getLanguageNameByCode: (String) -> String = { it },
-    val supportedLanguageTags: List<String> = DesktopBuildConfig.SUPPORTED_LANGUAGES,
+    val supportedLanguageTags: List<String> = SharedBuildConfig.SUPPORTED_LANGUAGES,
     @get:VisibleForTesting
     var databaseContext: CoroutineContext = Dispatchers.IO,
 ) {
@@ -190,6 +193,19 @@ class Dependencies(
 
     @VisibleForTesting
     var backgroundContext: CoroutineContext = Dispatchers.IO
+
+    // Passport
+    // The HTTP GET function the migrated fetch use cases call (descriptor links,
+    // articles, GeoIP release checks, proxy health). Exposed as a swappable var so
+    // instrumented tests can stub it directly without a fake PassportBridge.
+    @VisibleForTesting
+    var passportGet: (
+        url: String,
+        headers: List<PassportBridge.KeyValue>,
+        query: List<PassportBridge.KeyValue>,
+        proxy: String?,
+        timeout: Float?,
+    ) -> Result<PassportHttpResponse, PassportException> = passportBridge::get
 
     // Data
 
@@ -273,7 +289,8 @@ class Dependencies(
         FetchGeoIpDbUpdates(
             downloadFile = downloader::invoke,
             cacheDir = cacheDir,
-            engineHttpDo = engine::httpDo,
+            passportGet = passportGet,
+            getProxyOption = proxyManager::selected,
             json = json,
             preferencesRepository = preferenceRepository,
             fileSystem = FileSystem.SYSTEM,
@@ -387,7 +404,8 @@ class Dependencies(
     }
     private val fetchDescriptor by lazy {
         FetchDescriptor(
-            engineHttpDo = engine::httpDo,
+            passportGet = passportGet,
+            getProxyOption = proxyManager::selected,
             json = json,
         )
     }
@@ -646,16 +664,18 @@ class Dependencies(
             hasOoniNews = OrganizationConfig.hasOoniNews,
             sources = listOf(
                 GetRSSFeed(
-                    engine::httpDo,
+                    passportGet,
+                    proxyManager::selected,
                     "https://ooni.org/blog/index.xml",
                     ArticleModel.Source.Blog,
                 ),
                 GetRSSFeed(
-                    engine::httpDo,
+                    passportGet,
+                    proxyManager::selected,
                     "https://ooni.org/reports/index.xml",
                     ArticleModel.Source.Report,
                 ),
-                GetFindings(engine::httpDo, json),
+                GetFindings(passportGet, proxyManager::selected, json),
             ),
             networkTypeFinder = networkTypeFinder::invoke,
             refreshArticlesInDatabase = articleRepository::refresh,
@@ -736,7 +756,7 @@ class Dependencies(
     }
     private val testProxy by lazy {
         TestProxy(
-            httpDo = engine::httpDo,
+            passportGet = passportGet,
             getProxyOption = proxyManager::selected,
             backgroundContext = backgroundContext,
         )

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/FetchGeoIpDbUpdates.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/FetchGeoIpDbUpdates.kt
@@ -1,6 +1,7 @@
 package org.ooni.probe.domain
 
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
@@ -10,15 +11,18 @@ import kotlinx.serialization.json.Json
 import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toPath
-import org.ooni.engine.Engine
 import org.ooni.engine.Engine.MkException
 import org.ooni.engine.models.Failure
 import org.ooni.engine.models.Result
 import org.ooni.engine.models.Success
-import org.ooni.engine.models.TaskOrigin
+import org.ooni.passport.PassportBridge.KeyValue
+import org.ooni.passport.models.PassportException
+import org.ooni.passport.models.PassportHttpResponse
 import org.ooni.probe.data.models.GetBytesException
+import org.ooni.probe.data.models.ProxyOption
 import org.ooni.probe.data.models.SettingsKey
 import org.ooni.probe.data.repositories.PreferenceRepository
+import org.ooni.probe.domain.credentials.CredentialsConstants
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
@@ -27,7 +31,14 @@ import kotlin.time.Instant
 class FetchGeoIpDbUpdates(
     private val downloadFile: suspend (url: String, absoluteTargetPath: String) -> Result<Path, GetBytesException>,
     private val cacheDir: String,
-    private val engineHttpDo: suspend (method: String, url: String, taskOrigin: TaskOrigin) -> Result<String?, Engine.MkException>,
+    private val passportGet: (
+        url: String,
+        headers: List<KeyValue>,
+        query: List<KeyValue>,
+        proxy: String?,
+        timeout: Float?,
+    ) -> Result<PassportHttpResponse, PassportException>,
+    private val getProxyOption: () -> Flow<ProxyOption>,
     private val preferencesRepository: PreferenceRepository,
     private val json: Json,
     private val fileSystem: FileSystem,
@@ -119,20 +130,23 @@ class FetchGeoIpDbUpdates(
 
     private suspend fun getLatestEngineVersion(): Result<String?, MkException> {
         val url = "https://api.github.com/repos/${GEOIP_DB_REPO}/releases/latest"
+        val proxy = getProxyOption().first().value.takeIf { it.isNotEmpty() }
 
-        return engineHttpDo("GET", url, TaskOrigin.OoniRun).map { payload ->
-            payload?.let {
-                try {
-                    json.decodeFromString<GhRelease>(payload).tag
-                } catch (e: SerializationException) {
-                    Logger.e(e) { "Failed to decode release info" }
-                    null
-                } catch (e: IllegalArgumentException) {
-                    Logger.e(e) { "Failed to decode  release info" }
-                    null
+        return passportGet(url, emptyList(), emptyList(), proxy, CredentialsConstants.HTTP_TIMEOUT_SECONDS)
+            .mapError { MkException(it) }
+            .map { response ->
+                response.bodyText?.takeIf { response.isSuccessful }?.let { payload ->
+                    try {
+                        json.decodeFromString<GhRelease>(payload).tag
+                    } catch (e: SerializationException) {
+                        Logger.e(e) { "Failed to decode release info" }
+                        null
+                    } catch (e: IllegalArgumentException) {
+                        Logger.e(e) { "Failed to decode  release info" }
+                        null
+                    }
                 }
             }
-        }
     }
 
     private fun buildGeoIpDbUrl(version: String): String =

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/articles/GetFindings.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/articles/GetFindings.kt
@@ -1,35 +1,53 @@
 package org.ooni.probe.domain.articles
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.format.FormatStringsInDatetimeFormats
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import org.ooni.engine.Engine.MkException
 import org.ooni.engine.models.Failure
 import org.ooni.engine.models.Result
 import org.ooni.engine.models.Success
-import org.ooni.engine.models.TaskOrigin
+import org.ooni.passport.PassportBridge.KeyValue
+import org.ooni.passport.models.PassportException
+import org.ooni.passport.models.PassportHttpResponse
 import org.ooni.probe.config.OrganizationConfig
 import org.ooni.probe.data.models.ArticleModel
+import org.ooni.probe.data.models.ProxyOption
+import org.ooni.probe.domain.credentials.CredentialsConstants
 import org.ooni.probe.shared.toLocalDateTime
 import kotlin.time.Instant
 
 class GetFindings(
-    val httpDo: suspend (String, String, TaskOrigin) -> Result<String?, MkException>,
+    val passportGet: (
+        url: String,
+        headers: List<KeyValue>,
+        query: List<KeyValue>,
+        proxy: String?,
+        timeout: Float?,
+    ) -> Result<PassportHttpResponse, PassportException>,
+    val getProxyOption: () -> Flow<ProxyOption>,
     val json: Json,
 ) : RefreshArticles.Source {
     override suspend operator fun invoke(): Result<List<ArticleModel>, Exception> {
-        return httpDo(
-            "GET",
+        val proxy = getProxyOption().first().value.takeIf { it.isNotEmpty() }
+        return passportGet(
             "${OrganizationConfig.ooniApiBaseUrl}/api/v1/incidents/search",
-            TaskOrigin.OoniRun,
+            emptyList(),
+            emptyList(),
+            proxy,
+            CredentialsConstants.HTTP_TIMEOUT_SECONDS,
         ).mapError { it as Exception }
             .flatMap { response ->
-                if (response.isNullOrBlank()) return@flatMap Failure(Exception("Empty response"))
+                if (!response.isSuccessful) {
+                    return@flatMap Failure(Exception("Unsuccessful response (status=${response.statusCode})"))
+                }
+                if (response.bodyText.isNullOrBlank()) return@flatMap Failure(Exception("Empty response"))
 
                 val wrapper = try {
-                    json.decodeFromString<Wrapper>(response)
+                    json.decodeFromString<Wrapper>(response.bodyText)
                 } catch (e: Exception) {
                     return@flatMap Failure(e)
                 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/articles/GetRSSFeed.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/articles/GetRSSFeed.kt
@@ -1,5 +1,7 @@
 package org.ooni.probe.domain.articles
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.format.DateTimeComponents
 import kotlinx.datetime.format.DayOfWeekNames
@@ -12,28 +14,42 @@ import kotlinx.serialization.decodeFromString
 import nl.adaptivity.xmlutil.serialization.XML
 import nl.adaptivity.xmlutil.serialization.XmlElement
 import nl.adaptivity.xmlutil.serialization.XmlSerialName
-import org.ooni.engine.Engine.MkException
 import org.ooni.engine.models.Failure
 import org.ooni.engine.models.Result
 import org.ooni.engine.models.Success
-import org.ooni.engine.models.TaskOrigin
+import org.ooni.passport.PassportBridge.KeyValue
+import org.ooni.passport.models.PassportException
+import org.ooni.passport.models.PassportHttpResponse
 import org.ooni.probe.data.models.ArticleModel
+import org.ooni.probe.data.models.ProxyOption
+import org.ooni.probe.domain.credentials.CredentialsConstants
 import org.ooni.probe.shared.toLocalDateTime
 import kotlin.time.Instant
 
 class GetRSSFeed(
-    val httpDo: suspend (String, String, TaskOrigin) -> Result<String?, MkException>,
+    val passportGet: (
+        url: String,
+        headers: List<KeyValue>,
+        query: List<KeyValue>,
+        proxy: String?,
+        timeout: Float?,
+    ) -> Result<PassportHttpResponse, PassportException>,
+    val getProxyOption: () -> Flow<ProxyOption>,
     val url: String,
     val source: ArticleModel.Source,
 ) : RefreshArticles.Source {
     override suspend operator fun invoke(): Result<List<ArticleModel>, Exception> {
-        return httpDo("GET", url, TaskOrigin.OoniRun)
+        val proxy = getProxyOption().first().value.takeIf { it.isNotEmpty() }
+        return passportGet(url, emptyList(), emptyList(), proxy, CredentialsConstants.HTTP_TIMEOUT_SECONDS)
             .mapError { it as Exception }
             .flatMap { response ->
-                if (response.isNullOrBlank()) return@flatMap Failure(Exception("Empty response"))
+                if (!response.isSuccessful) {
+                    return@flatMap Failure(Exception("Unsuccessful response (status=${response.statusCode})"))
+                }
+                if (response.bodyText.isNullOrBlank()) return@flatMap Failure(Exception("Empty response"))
 
                 val rss = try {
-                    xml().decodeFromString<Rss>(response)
+                    xml().decodeFromString<Rss>(response.bodyText)
                 } catch (e: Exception) {
                     return@flatMap Failure(e)
                 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/descriptors/FetchDescriptor.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/descriptors/FetchDescriptor.kt
@@ -1,36 +1,63 @@
 package org.ooni.probe.domain.descriptors
 
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import org.ooni.engine.Engine.MkException
+import org.ooni.engine.models.Failure
 import org.ooni.engine.models.OONIRunDescriptor
 import org.ooni.engine.models.Result
-import org.ooni.engine.models.TaskOrigin
+import org.ooni.engine.models.Success
 import org.ooni.engine.models.toModel
+import org.ooni.passport.PassportBridge.KeyValue
+import org.ooni.passport.models.PassportException
+import org.ooni.passport.models.PassportHttpResponse
 import org.ooni.probe.config.OrganizationConfig
 import org.ooni.probe.data.models.Descriptor
+import org.ooni.probe.data.models.ProxyOption
+import org.ooni.probe.domain.credentials.CredentialsConstants
 
 class FetchDescriptor(
-    private val engineHttpDo: suspend (method: String, url: String, taskOrigin: TaskOrigin) -> Result<String?, MkException>,
+    private val passportGet: (
+        url: String,
+        headers: List<KeyValue>,
+        query: List<KeyValue>,
+        proxy: String?,
+        timeout: Float?,
+    ) -> Result<PassportHttpResponse, PassportException>,
+    private val getProxyOption: () -> Flow<ProxyOption>,
     private val json: Json,
 ) {
-    suspend operator fun invoke(descriptorId: Descriptor.Id): Result<Descriptor?, MkException> =
-        engineHttpDo(
-            "GET",
+    suspend operator fun invoke(descriptorId: Descriptor.Id): Result<Descriptor?, MkException> {
+        val proxy = getProxyOption().first().value.takeIf { it.isNotEmpty() }
+        return passportGet(
             "${OrganizationConfig.ooniApiBaseUrl}/api/v2/oonirun/links/${descriptorId.value}",
-            TaskOrigin.OoniRun,
-        ).map { result ->
-            result?.let {
-                try {
-                    json.decodeFromString<OONIRunDescriptor>(it).toModel()
-                } catch (e: SerializationException) {
-                    Logger.e(e) { "Failed to decode descriptor ${descriptorId.value}" }
-                    null
-                } catch (e: IllegalArgumentException) {
-                    Logger.e(e) { "Failed to decode descriptor ${descriptorId.value}" }
-                    null
+            emptyList(),
+            emptyList(),
+            proxy,
+            CredentialsConstants.HTTP_TIMEOUT_SECONDS,
+        ).mapError { MkException(it) }
+            .flatMap { response ->
+                if (!response.isSuccessful) {
+                    return@flatMap Failure(
+                        MkException(Throwable("Failed to fetch descriptor (status=${response.statusCode})")),
+                    )
                 }
-            } ?: throw MkException(Throwable("Failed to fetch descriptor"))
-        }
+                Success(
+                    response.bodyText?.let {
+                        try {
+                            json.decodeFromString<OONIRunDescriptor>(it).toModel()
+                        } catch (e: SerializationException) {
+                            Logger.e(e) { "Failed to decode descriptor ${descriptorId.value}" }
+                            null
+                        } catch (e: IllegalArgumentException) {
+                            Logger.e(e) { "Failed to decode descriptor ${descriptorId.value}" }
+                            null
+                        }
+                    } ?: throw MkException(Throwable("Failed to fetch descriptor")),
+                )
+            }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/proxy/TestProxy.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/proxy/TestProxy.kt
@@ -4,16 +4,23 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
-import org.ooni.engine.Engine.MkException
 import org.ooni.engine.models.Result
-import org.ooni.engine.models.Success
-import org.ooni.engine.models.TaskOrigin
+import org.ooni.passport.PassportBridge.KeyValue
+import org.ooni.passport.models.PassportException
+import org.ooni.passport.models.PassportHttpResponse
 import org.ooni.probe.config.OrganizationConfig
 import org.ooni.probe.data.models.ProxyOption
+import org.ooni.probe.domain.credentials.CredentialsConstants
 import kotlin.coroutines.CoroutineContext
 
 class TestProxy(
-    val httpDo: suspend (String, String, TaskOrigin, ProxyOption?) -> Result<String?, MkException>,
+    private val passportGet: (
+        url: String,
+        headers: List<KeyValue>,
+        query: List<KeyValue>,
+        proxy: String?,
+        timeout: Float?,
+    ) -> Result<PassportHttpResponse, PassportException>,
     private val getProxyOption: () -> Flow<ProxyOption>,
     private val backgroundContext: CoroutineContext,
 ) {
@@ -27,9 +34,14 @@ class TestProxy(
                 return@channelFlow
             }
 
-            if (
-                httpDo("GET", "${OrganizationConfig.ooniApiBaseUrl}/health", TaskOrigin.OoniRun, proxy) is Success
-            ) {
+            val response = passportGet(
+                "${OrganizationConfig.ooniApiBaseUrl}/health",
+                emptyList(),
+                emptyList(),
+                proxy.value.takeIf { it.isNotEmpty() },
+                CredentialsConstants.HTTP_TIMEOUT_SECONDS,
+            )
+            if (response.get()?.isSuccessful == true) {
                 send(State.Available)
             } else {
                 send(State.Unavailable)

--- a/composeApp/src/commonTest/kotlin/org/ooni/probe/domain/articles/GetFindingsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/probe/domain/articles/GetFindingsTest.kt
@@ -1,7 +1,10 @@
 package org.ooni.probe.domain.articles
 
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.ooni.engine.models.Success
+import org.ooni.passport.models.PassportHttpResponse
+import org.ooni.probe.data.models.ProxyOption
 import org.ooni.probe.di.Dependencies
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -12,7 +15,10 @@ class GetFindingsTest {
     fun invoke() =
         runTest {
             val subject = GetFindings(
-                httpDo = { _, _, _ -> Success(API_RESPONSE) },
+                passportGet = { _, _, _, _, _ ->
+                    Success(PassportHttpResponse(200, "HTTP/1.1", emptyList(), API_RESPONSE))
+                },
+                getProxyOption = { flowOf(ProxyOption.None) },
                 json = Dependencies.buildJson(),
             )
 

--- a/composeApp/src/commonTest/kotlin/org/ooni/probe/domain/articles/GetRssFeedTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/probe/domain/articles/GetRssFeedTest.kt
@@ -1,8 +1,11 @@
 package org.ooni.probe.domain.articles
 
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.ooni.engine.models.Success
+import org.ooni.passport.models.PassportHttpResponse
 import org.ooni.probe.data.models.ArticleModel
+import org.ooni.probe.data.models.ProxyOption
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -11,7 +14,10 @@ class GetRssFeedTest {
     fun invoke() =
         runTest {
             val subject = GetRSSFeed(
-                httpDo = { _, _, _ -> Success(RSS_FEED) },
+                passportGet = { _, _, _, _, _ ->
+                    Success(PassportHttpResponse(200, "HTTP/1.1", emptyList(), RSS_FEED))
+                },
+                getProxyOption = { flowOf(ProxyOption.None) },
                 url = "https://example.org",
                 source = ArticleModel.Source.Blog,
             )


### PR DESCRIPTION
Closes https://github.com/ooni/probe-multiplatform/issues/1458