### PR TITLE
Avoid triple reporting issues with retrieving manifest

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/credentials/PrepareAnonymousCredentials.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/credentials/PrepareAnonymousCredentials.kt
@@ -42,7 +42,7 @@ class PrepareAnonymousCredentials(
 
             val manifest = getOrRetrieveManifest()
             if (manifest == null) {
-                Logger.w("No manifest available for user registration")
+                Logger.i("No manifest available for user registration")
                 return null
             }
 
@@ -73,7 +73,7 @@ class PrepareAnonymousCredentials(
         Logger.i("No cached manifest found, retrieving manifest from API")
         val retrieved = retrieveManifest()
         if (retrieved == null) {
-            Logger.w("Failed to retrieve manifest from API")
+            Logger.i("Failed to retrieve manifest from API")
         } else {
             Logger.i("Successfully retrieved manifest from API")
         }


### PR DESCRIPTION
When the API call to retrieve a manifest failed, we were reporting it 3 times to Sentry. We just need the report inside `RetrieveManifest`.