### PR TITLE
Avoid duplicated warning reports on user registration

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/credentials/PrepareAnonymousCredentials.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/credentials/PrepareAnonymousCredentials.kt
@@ -53,7 +53,7 @@ class PrepareAnonymousCredentials(
 
             val credential = registerUser(publicParameters, manifestVersion)
             if (credential == null) {
-                Logger.w("User registration failed: registerUser returned null credential")
+                Logger.i("User registration failed: registerUser returned null credential")
             } else {
                 Logger.i("User registered successfully: credential obtained")
             }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/credentials/RegisterUser.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/credentials/RegisterUser.kt
@@ -36,14 +36,14 @@ class RegisterUser(
 
                     val credential = credentialResponse.decodeCredential(json)
                     if (credential == null) {
-                        Logger.w("Failed to register user (could not decode credential)")
+                        Logger.i("Failed to register user (could not decode credential)")
                         return@withContext null
                     }
 
                     return@withContext if (setCredential(credential)) {
                         credential
                     } else {
-                        Logger.w("Failed to register user: could not store credential in secure storage")
+                        Logger.i("Failed to register user: could not store credential in secure storage")
                         null
                     }
                 }.onFailure { exception ->


### PR DESCRIPTION
We're already reporting from inside `CredentialResponse` and `SetCredential`.