### PR TITLE
fix: differ credential storage for `errSecInteractionNotAllowed`

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/engine/SecureStorageResult.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/engine/SecureStorageResult.kt
@@ -30,6 +30,14 @@ sealed interface WriteResult {
         val message: String?,
         val cause: Throwable? = null,
     ) : WriteResult
+
+    /**
+     * Indicates storage is temporarily inaccessible (e.g., iOS keychain locked after reboot).
+     * Callers should defer the operation instead of treating it as a failure.
+     */
+    data class TemporarilyUnavailable(
+        val key: String,
+    ) : WriteResult
 }
 
 sealed interface DeleteAllResult {

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/credentials/SetCredential.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/credentials/SetCredential.kt
@@ -21,6 +21,11 @@ class SetCredential(
                     Logger.w("Failed to store credentials in secure storage: ${result.message}", result.cause)
                     false
                 }
+                is WriteResult.TemporarilyUnavailable -> {
+                    // Device locked (pre-first-unlock background run);
+                    Logger.i("Secure storage temporarily unavailable, deferring credential storage")
+                    false
+                }
             }
         } catch (e: Exception) {
             Logger.w("Failed to store credentials", e)

--- a/composeApp/src/commonTest/kotlin/org/ooni/probe/domain/credentials/SetCredentialTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/probe/domain/credentials/SetCredentialTest.kt
@@ -1,0 +1,65 @@
+package org.ooni.probe.domain.credentials
+
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.ooni.engine.WriteResult
+import org.ooni.probe.data.models.Credential
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SetCredentialTest {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val credential = Credential(credential = "credential", emissionDay = 42u)
+
+    @Test
+    fun created() =
+        runTest {
+            var storedValue: String? = null
+            val setCredential = SetCredential(
+                writeSecureStorage = { key, value ->
+                    assertEquals(CredentialsConstants.STORAGE_KEY, key)
+                    storedValue = value
+                    WriteResult.Created(key)
+                },
+                json = json,
+            )
+
+            assertTrue(setCredential(credential))
+            assertEquals(json.encodeToString(Credential.serializer(), credential), storedValue)
+        }
+
+    @Test
+    fun error() =
+        runTest {
+            val setCredential = SetCredential(
+                writeSecureStorage = { key, _ -> WriteResult.Error(key, "failure") },
+                json = json,
+            )
+
+            assertFalse(setCredential(credential))
+        }
+
+    @Test
+    fun temporarilyUnavailable() =
+        runTest {
+            val setCredential = SetCredential(
+                writeSecureStorage = { key, _ -> WriteResult.TemporarilyUnavailable(key) },
+                json = json,
+            )
+
+            assertFalse(setCredential(credential))
+        }
+
+    @Test
+    fun exception() =
+        runTest {
+            val setCredential = SetCredential(
+                writeSecureStorage = { _, _ -> throw IllegalStateException("failure") },
+                json = json,
+            )
+
+            assertFalse(setCredential(credential))
+        }
+}

--- a/composeApp/src/iosMain/kotlin/org/ooni/engine/IosSecureStorage.kt
+++ b/composeApp/src/iosMain/kotlin/org/ooni/engine/IosSecureStorage.kt
@@ -26,8 +26,11 @@ import platform.Security.SecItemCopyMatching
 import platform.Security.SecItemDelete
 import platform.Security.SecItemUpdate
 import platform.Security.errSecDuplicateItem
+import platform.Security.errSecInteractionNotAllowed
 import platform.Security.errSecItemNotFound
 import platform.Security.errSecSuccess
+import platform.Security.kSecAttrAccessible
+import platform.Security.kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
 import platform.Security.kSecAttrAccount
 import platform.Security.kSecAttrService
 import platform.Security.kSecClass
@@ -74,7 +77,10 @@ class IosSecureStorage(
             val valueData = nsString.dataUsingEncoding(NSUTF8StringEncoding) ?: return@withContext WriteResult.Error(key, "encode failed")
             val valueDataRef = CFBridgingRetain(valueData)
 
-            val addQuery = buildQuery(key) { addEntry(kSecValueData, valueDataRef) }
+            val addQuery = buildQuery(key) {
+                addEntry(kSecValueData, valueDataRef)
+                addEntry(kSecAttrAccessible, kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
+            }
             val addStatus = SecItemAdd(addQuery, null)
             val wasCreated = addStatus == errSecSuccess
 
@@ -82,19 +88,26 @@ class IosSecureStorage(
                 CFBridgingRelease(addQuery)
                 if (addStatus == errSecDuplicateItem) {
                     val updateQuery = buildQuery(key)
-                    val attributes = buildCFDictionary { addEntry(kSecValueData, valueDataRef) }
+                    val attributes = buildCFDictionary {
+                        addEntry(kSecValueData, valueDataRef)
+                        addEntry(kSecAttrAccessible, kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
+                    }
                     val updateStatus = SecItemUpdate(updateQuery, attributes)
                     CFBridgingRelease(updateQuery)
                     CFBridgingRelease(attributes)
                     CFBridgingRelease(valueDataRef)
-                    return@withContext if (updateStatus == errSecSuccess) {
-                        WriteResult.Updated(key)
-                    } else {
-                        WriteResult.Error(key, "osstatus=$updateStatus")
+                    return@withContext when (updateStatus) {
+                        errSecSuccess -> WriteResult.Updated(key)
+                        errSecInteractionNotAllowed -> WriteResult.TemporarilyUnavailable(key)
+                        else -> WriteResult.Error(key, "osstatus=$updateStatus")
                     }
                 }
                 CFBridgingRelease(valueDataRef)
-                return@withContext WriteResult.Error(key, "osstatus=$addStatus")
+                return@withContext if (addStatus == errSecInteractionNotAllowed) {
+                    WriteResult.TemporarilyUnavailable(key)
+                } else {
+                    WriteResult.Error(key, "osstatus=$addStatus")
+                }
             }
 
             CFBridgingRelease(addQuery)


### PR DESCRIPTION
Closes https://github.com/ooni/probe-multiplatform/issues/1523

[`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`](https://developer.apple.com/documentation/security/ksecattraccessibleafterfirstunlockthisdeviceonly) : "The data in the keychain item can always be accessed **after the first unlock** of the device"