### PR TITLE
Fix results missing after midnight

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/data/models/ResultFilter.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/data/models/ResultFilter.kt
@@ -1,8 +1,10 @@
 package org.ooni.probe.data.models
 
 import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.minus
+import kotlinx.datetime.plus
 import org.ooni.engine.models.TaskOrigin
 import org.ooni.probe.shared.today
 
@@ -22,26 +24,28 @@ data class ResultFilter(
             (if (dates == ResultFilter().dates) 0 else 1)
 
     sealed class Date(
-        val range: ClosedRange<LocalDate>,
+        val range: () -> ClosedRange<LocalDate>,
     ) {
         data object AnyDate :
-            Date(LocalDate(2000, 1, 1)..LocalDate.today())
+            Date(range = { MIN_DATE..MAX_DATE })
 
         data object Today :
-            Date(LocalDate.today()..LocalDate.today())
+            Date(range = { LocalDate.today()..MAX_DATE })
 
         data object FromSevenDaysAgo :
-            Date(LocalDate.today().minus(DatePeriod(days = 7))..LocalDate.today())
+            Date(range = { LocalDate.today().minus(DatePeriod(days = 7))..MAX_DATE })
 
         data object FromOneMonthAgo :
-            Date(LocalDate.today().minus(DatePeriod(months = 1))..LocalDate.today())
+            Date(range = { LocalDate.today().minus(DatePeriod(months = 1))..MAX_DATE })
 
         data class Custom(
             val customRange: ClosedRange<LocalDate>,
-        ) : Date(customRange)
+        ) : Date({ customRange })
     }
 
     companion object {
         const val LIMIT = 100L
+        private val MIN_DATE = LocalDate(2000, 1, 1)
+        private val MAX_DATE = LocalDate.today().plus(1, DateTimeUnit.YEAR)
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/data/repositories/ResultRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/data/repositories/ResultRepository.kt
@@ -310,21 +310,23 @@ class ResultRepository(
         val limit: Long,
     ) {
         companion object {
-            fun build(filter: ResultFilter) =
-                FilterParams(
+            fun build(filter: ResultFilter): FilterParams {
+                val range = filter.dates.range()
+                return FilterParams(
                     filterByDescriptors = if (filter.descriptors.any()) 1 else 0,
                     descriptorsKeys = filter.descriptors.map { it.key },
                     filterByNetworks = if (filter.networks.any()) 1 else 0,
                     networkIds = filter.networks.mapNotNull { it.id?.value },
                     filterByTaskOrigin = if (filter.taskOrigin != null) 1 else 0,
                     taskOrigin = filter.taskOrigin?.value,
-                    startFrom = filter.dates.range.start
+                    startFrom = range.start
                         .toEpoch(),
-                    startUntil = filter.dates.range.endInclusive
+                    startUntil = range.endInclusive
                         .atTime(23, 59, 59)
                         .toEpoch(),
                     limit = filter.limit,
                 )
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/results/ResultFilterViews.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/ui/results/ResultFilterViews.kt
@@ -384,7 +384,7 @@ private fun DateFilter(
 
     if (showDatePicker) {
         val initialRange = (filter.dates as? ResultFilter.Date.Custom)?.customRange
-        val selectableRange = ResultFilter.Date.AnyDate.range
+        val selectableRange = ResultFilter.Date.AnyDate.range()
         val selectableYearRange = selectableRange.let { it.start.year..it.endInclusive.year }
 
         val dateRangePickerState = rememberDateRangePickerState(


### PR DESCRIPTION
Closes https://github.com/ooni/probe-multiplatform/issues/1531

The lambda ensures that new dates are created whenever we create a new filter (every time the `ResultsViewModel` is instantiated). The `MAX_DATE` covers the scenario where the app stays opened on the `ResultsScreen/ViewModel` for a long time.