### PR TITLE
fix(download): keep HTTP client alive during cleanup

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/DownloadFile.kt
+++ b/composeApp/src/commonMain/kotlin/org/ooni/probe/domain/DownloadFile.kt
@@ -27,6 +27,8 @@ class DownloadFile(
     private val isOnline: () -> Boolean,
     private val httpClientFactory: () -> HttpClient = ::defaultHttpClient,
 ) {
+    private val httpClient by lazy(httpClientFactory)
+
     suspend operator fun invoke(
         url: String,
         absoluteTargetPath: String,
@@ -53,10 +55,8 @@ class DownloadFile(
             )
         }
 
-        val client = httpClientFactory()
-
         return try {
-            val response = client.get(url)
+            val response = httpClient.get(url)
             val bytes = response.bodyAsBytes()
 
             if (response.status.isSuccess()) {
@@ -70,8 +70,6 @@ class DownloadFile(
             }
         } catch (e: Throwable) {
             Failure(GetBytesException(e))
-        } finally {
-            client.close()
         }
     }
 }

--- a/composeApp/src/commonTest/kotlin/org/ooni/probe/domain/DownloadFileTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/ooni/probe/domain/DownloadFileTest.kt
@@ -1,5 +1,7 @@
 package org.ooni.probe.domain
 
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.test.runTest
 import okio.FileSystem
 import org.ooni.passport.models.PassportException
@@ -10,6 +12,22 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class DownloadFileTest {
+    @Test
+    fun failedDownloadKeepsTheReusableHttpClientOpen() =
+        runTest {
+            val client = HttpClient()
+            val subject = DownloadFile(
+                fileSystem = FileSystem.SYSTEM,
+                isOnline = { true },
+                httpClientFactory = { client },
+            )
+
+            subject.fetchBytes("not a URL")
+
+            assertTrue(client.coroutineContext.isActive)
+            client.close()
+        }
+
     @Test
     fun offlineNeverBuildsAnHttpClient() =
         runTest {


### PR DESCRIPTION
Closes https://github.com/ooni/probe-multiplatform/issues/1526