### PR TITLE
fix: catch and log exceptions in `setRunAtStartup`

### DIFF
--- a/composeApp/src/desktopMain/kotlin/org/ooni/probe/BuildDependencies.kt
+++ b/composeApp/src/desktopMain/kotlin/org/ooni/probe/BuildDependencies.kt
@@ -70,9 +70,12 @@ private val databaseDispatcher by lazy {
  * cross-platform AutoLaunch library (macOS LaunchAgent, Windows Run key, Linux
  * autostart entry).
  */
-internal suspend fun setRunAtStartup(enabled: Boolean) {
-    if (enabled) autoLaunch.enable() else autoLaunch.disable()
-}
+internal suspend fun setRunAtStartup(enabled: Boolean) =
+    try {
+        if (enabled) autoLaunch.enable() else autoLaunch.disable()
+    } catch (e: Exception) {
+        Logger.e(e) { "Failed to set run at startup" }
+    }
 
 private val backgroundWorkManager: BackgroundWorkManager = BackgroundWorkManager(
     runBackgroundTaskProvider = { dependencies.runBackgroundTask },


### PR DESCRIPTION
Closes https://github.com/ooni/probe-multiplatform/issues/1556